### PR TITLE
Add initial Dockerfile build config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+deploy
+.git*
+.github
+__pycache__
+*.egg-info
+.eggs
+*pytest_cache*
+.coverage
+*.py[cxo]
+.ipynb_checkpoints
+__pytest__
+.xprocess

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM continuumio/miniconda3:4.9.2
+
+ENV PATH /opt/conda/bin:$PATH
+
+# Copy only app requirements to cache dependencies
+RUN mkdir /opt/dodola
+COPY requirements.txt /opt/dodola/requirements.txt
+RUN bash -c "conda install -c conda-forge --file /opt/dodola/requirements.txt \
+    && conda clean --all"
+
+COPY . /opt/dodola
+RUN bash -c "pip install /opt/dodola"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click
 cftime
 numpy
+pytest
 scikit-downscale
 xarray

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     zip_safe=False,
     python_requires=">=3.7",
     install_requires=requirements,
-    setup_requires=["setuptools_scm"],
     entry_points="""
     [console_scripts]
     dodola=dodola.cli:dodola_cli


### PR DESCRIPTION
Biggest change here is the addition of files needed to containerize the application.

Building and testing this locally with:
```shell
docker build --tag dodola:dev .

docker run dodola:dev pytest -v --pyargs dodola
```

Additional changes:

- Add `pytest` to requirements.txt so can test package within container.
- Drop `setuptools_scm` package from `setup_requires`. We're not using `setuptools_scm` for package versioning anyways and this might create problems for container build without a network.

Close #6