### PR TITLE
Add initial container-based CICD workflow

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,28 @@
+name: Build, test, push container
+
+on:
+  push:
+    branches: "main"
+
+jobs:
+  buildcontainer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build container
+      run: |
+        docker build . -t ${{ secrets.ACR_LOGIN_SERVER }}/dodola:dev
+    - name: Test container package
+      run: |
+        docker run ${{ secrets.ACR_LOGIN_SERVER }}/dodola:dev pytest -v --pyargs dodola
+    - name: Test container CLI
+      run: |
+        docker run ${{ secrets.ACR_LOGIN_SERVER }}/dodola:dev dodola --help
+    - name: Push to registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.ACR_LOGIN_SERVER }}
+        username: ${{ secrets.ACR_USERNAME }}
+        password: ${{ secrets.ACR_PASSWORD }}
+      run: |
+        docker push ${{ secrets.ACR_LOGIN_SERVER }}/dodola:dev

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -2,13 +2,19 @@ name: Build, test, push container
 
 on:
   push:
-    branches: "main"
+    branches:
+    - "main"
 
 jobs:
   buildcontainer:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.ACR_LOGIN_SERVER }}
+        username: ${{ secrets.ACR_USERNAME }}
+        password: ${{ secrets.ACR_PASSWORD }}
     - name: Build container
       run: |
         docker build . -t ${{ secrets.ACR_LOGIN_SERVER }}/dodola:dev
@@ -19,10 +25,5 @@ jobs:
       run: |
         docker run ${{ secrets.ACR_LOGIN_SERVER }}/dodola:dev dodola --help
     - name: Push to registry
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.ACR_LOGIN_SERVER }}
-        username: ${{ secrets.ACR_USERNAME }}
-        password: ${{ secrets.ACR_PASSWORD }}
       run: |
         docker push ${{ secrets.ACR_LOGIN_SERVER }}/dodola:dev


### PR DESCRIPTION
Adds a new Github Actions workflow to build, test, and push a Docker container image to a private container registry. This workflow is triggered on pushes to `main`.

Close #8.