### PR TITLE
Add prototype support for Azure Data Lake Gen2 storage

### DIFF
--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -13,17 +13,58 @@ def dodola_cli():
 
 
 @dodola_cli.command(help="Bias-correct GCM on observations")
-@click.argument("x", required=True)
-@click.argument("xtrain", required=True)
-@click.argument("trainvariable", required=True)
-@click.argument("ytrain", required=True)
-@click.argument("out", required=True)
-@click.argument("outvariable", required=True)
-@click.option("--azstorageaccount", default=None, envvar="AZURE_STORAGE_ACCOUNT")
-@click.option("--azstoragekey", default=None, envvar="AZURE_STORAGE_KEY")
-@click.option("--azclientid", default=None, envvar="AZURE_CLIENT_ID")
-@click.option("--azclientsecret", default=None, envvar="AZURE_CLIENT_SECRET")
-@click.option("--aztenantid", default=None, envvar="AZURE_TENANT_ID")
+@click.argument(
+    "x",
+    required=True,
+    help="URL of Zarr store to extract independent variable or GCM data for training.",
+)
+@click.argument(
+    "xtrain",
+    required=True,
+    help="URL of Zarr store to extract independent variable or obs for training.",
+)
+@click.argument(
+    "trainvariable", required=True, help="Variable to extract for training."
+)
+@click.argument(
+    "ytrain",
+    required=True,
+    help="URL of Zarr store to extract dependant variable for training.",
+)
+@click.argument("out", required=True, help="URL of store to write output Zarr data to.")
+@click.argument(
+    "outvariable", required=True, help="Variable name to assign output in output file."
+)
+@click.option(
+    "--azstorageaccount",
+    default=None,
+    envvar="AZURE_STORAGE_ACCOUNT",
+    help="Key-based Azure storage credential",
+)
+@click.option(
+    "--azstoragekey",
+    default=None,
+    envvar="AZURE_STORAGE_KEY",
+    help="Key-based Azure storage credential",
+)
+@click.option(
+    "--azclientid",
+    default=None,
+    envvar="AZURE_CLIENT_ID",
+    help="Service Principal-based Azure storage credential",
+)
+@click.option(
+    "--azclientsecret",
+    default=None,
+    envvar="AZURE_CLIENT_SECRET",
+    help="Service Principal-based Azure storage credential",
+)
+@click.option(
+    "--aztenantid",
+    default=None,
+    envvar="AZURE_TENANT_ID",
+    help="Service Principal-based Azure storage credential",
+)
 def biascorrect(
     x,
     xtrain,

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -3,7 +3,7 @@
 
 import click
 import dodola.services as services
-from dodola.repository import GcsRepository
+from dodola.repository import AzureZarr
 
 
 # Main entry point
@@ -19,9 +19,34 @@ def dodola_cli():
 @click.argument("ytrain", required=True)
 @click.argument("out", required=True)
 @click.argument("outvariable", required=True)
-def biascorrect(x, xtrain, trainvariable, ytrain, out, outvariable):
+@click.option("--azstorageaccount", default=None, envvar="AZURE_STORAGE_ACCOUNT")
+@click.option("--azstoragekey", default=None, envvar="AZURE_STORAGE_KEY")
+@click.option("--azclientid", default=None, envvar="AZURE_CLIENT_ID")
+@click.option("--azclientsecret", default=None, envvar="AZURE_CLIENT_SECRET")
+@click.option("--aztenantid", default=None, envvar="AZURE_TENANT_ID")
+def biascorrect(
+    x,
+    xtrain,
+    trainvariable,
+    ytrain,
+    out,
+    outvariable,
+    azstorageaccount,
+    azstoragekey,
+    azclientid,
+    azclientsecret,
+    aztenantid,
+):
     """Bias-correct GCM (x) to 'out' based on model (xtrain), obs (ytrain)"""
-    storage = GcsRepository()
+
+    # Configure storage while we have access to users configurations.
+    storage = AzureZarr(
+        account_name=azstorageaccount,
+        account_key=azstoragekey,
+        client_id=azclientid,
+        client_secret=azclientsecret,
+        tenant_id=aztenantid,
+    )
     services.bias_correct(
         x,
         xtrain,

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -13,28 +13,15 @@ def dodola_cli():
 
 
 @dodola_cli.command(help="Bias-correct GCM on observations")
-@click.argument(
-    "x",
-    required=True,
-    help="URL of Zarr store to extract independent variable or GCM data for training.",
-)
-@click.argument(
-    "xtrain",
-    required=True,
-    help="URL of Zarr store to extract independent variable or obs for training.",
-)
-@click.argument(
-    "trainvariable", required=True, help="Variable to extract for training."
-)
+@click.argument("x", required=True)
+@click.argument("xtrain", required=True)
+@click.argument("trainvariable", required=True)
 @click.argument(
     "ytrain",
     required=True,
-    help="URL of Zarr store to extract dependant variable for training.",
 )
-@click.argument("out", required=True, help="URL of store to write output Zarr data to.")
-@click.argument(
-    "outvariable", required=True, help="Variable name to assign output in output file."
-)
+@click.argument("out", required=True)
+@click.argument("outvariable", required=True)
 @click.option(
     "--azstorageaccount",
     default=None,

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -101,19 +101,6 @@ class AzureZarr(RepositoryABC):
         x.to_zarr(self.fs.get_mapper(url_or_path), mode="w", compute=True)
 
 
-class GcsRepository(RepositoryABC):
-    """Google Cloud Storage bucket-based repository.
-
-    Prob will use ``gcsfs``.
-    """
-
-    def read(self, url_or_path):
-        raise NotImplementedError
-
-    def write(self, url_or_path, x):
-        raise NotImplementedError
-
-
 class FakeRepository(RepositoryABC):
     """Simple in-memory repository for testing
 

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -56,7 +56,14 @@ class AzureZarr(RepositoryABC):
     tenant_id : str or None, optional
     """
 
-    def __init__(self, account_name=None, account_key=None, client_id=None, client_secret=None, tenant_id=None):
+    def __init__(
+        self,
+        account_name=None,
+        account_key=None,
+        client_id=None,
+        client_secret=None,
+        tenant_id=None,
+    ):
         self.fs = AzureBlobFileSystem(
             account_name=account_name,
             account_key=account_key,

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -2,7 +2,6 @@
 """
 
 from dodola.core import bias_correct_bcsd
-from dodola.repository import GcsRepository
 
 
 def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage):

--- a/dodola/tests/test_repository.py
+++ b/dodola/tests/test_repository.py
@@ -1,0 +1,14 @@
+from dodola.repository import FakeRepository
+
+
+def test_fakerepository_read():
+    """Basic test that FakeRepository.read() works"""
+    storage = FakeRepository(storage={"foo": "bar"})
+    assert storage.read(url_or_path="foo") == "bar"
+
+
+def test_fakerepository_write():
+    """Basic test that FakeRepository.write() works"""
+    storage = FakeRepository(storage={"foo": "bar"})
+    storage.write(url_or_path="foo", x="SPAM")
+    assert storage.read(url_or_path="foo") == "SPAM"

--- a/environment.yaml
+++ b/environment.yaml
@@ -2,6 +2,7 @@ name: base
 channels:
 - conda-forge
 dependencies:
+- adlfs
 - click
 - cftime
 - numpy

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,5 +11,6 @@ dependencies:
 - python=3.8
 - xarray
 - bottleneck
+- zarr
 - pip:
   - git+https://github.com/dgergel/xsd@pointwisedownscaler_interimfix


### PR DESCRIPTION
Adds `dodola.repository.AzureZarr`, giving us basic support to stream Zarr files to and from Azure Data Lake Gen2 storage.

This authenticates with storage account keys or service credentials via environment variables. For storage account key authentication set `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY`.
Alternatively, for service principals authentication, set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID`.

There is also an option to just set credentials at the command line.

With storage credentials set to environment variables, call `biascorrect` from the CLI with:
```
dodola biascorrect cleanstore/input.zarr cleanstore/training.zarr cleanstore/obs.zarr productstore/output.zarr
```

Other changes:

- Add tests for a repository subclass.
- Clean out old, unused classes.
- Very minor improvements to documentation.

Close #13.