### PR TITLE
Add ESMF weights file-building service, logging

### DIFF
--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -105,6 +105,12 @@ def biascorrect(
     help="Regridding method - 'bilinear' or 'conservative'",
 )
 @click.option(
+    "--targetresolution",
+    "-r",
+    default=1.0,
+    help="Global-grid resolution to regrid to",
+)
+@click.option(
     "--outpath",
     "-o",
     default=None,
@@ -143,6 +149,7 @@ def biascorrect(
 def buildweights(
     x,
     method,
+    targetgrid,
     outpath,
     azstorageaccount,
     azstoragekey,
@@ -165,4 +172,10 @@ def buildweights(
         client_secret=azclientsecret,
         tenant_id=aztenantid,
     )
-    services.build_weights(str(x), str(method), storage=storage, outpath=str(outpath))
+    services.build_weights(
+        str(x),
+        str(method),
+        target_resolution=float(targetgrid),
+        storage=storage,
+        outpath=str(outpath),
+    )

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -84,3 +84,75 @@ def biascorrect(
         train_variable=trainvariable,
         out_variable=outvariable,
     )
+
+
+@dodola_cli.command(help="Build NetCDF weights file for regridding")
+@click.argument("x", required=True)
+@click.option(
+    "--method",
+    "-m",
+    required=True,
+    help="Regridding method - 'bilinear' or 'conservative'",
+)
+@click.option(
+    "--outpath",
+    "-o",
+    default=None,
+    help="Local path to write weights file",
+)
+@click.option(
+    "--azstorageaccount",
+    default=None,
+    envvar="AZURE_STORAGE_ACCOUNT",
+    help="Key-based Azure storage credential",
+)
+@click.option(
+    "--azstoragekey",
+    default=None,
+    envvar="AZURE_STORAGE_KEY",
+    help="Key-based Azure storage credential",
+)
+@click.option(
+    "--azclientid",
+    default=None,
+    envvar="AZURE_CLIENT_ID",
+    help="Service Principal-based Azure storage credential",
+)
+@click.option(
+    "--azclientsecret",
+    default=None,
+    envvar="AZURE_CLIENT_SECRET",
+    help="Service Principal-based Azure storage credential",
+)
+@click.option(
+    "--aztenantid",
+    default=None,
+    envvar="AZURE_TENANT_ID",
+    help="Service Principal-based Azure storage credential",
+)
+def buildweights(
+    x,
+    method,
+    outpath,
+    azstorageaccount,
+    azstoragekey,
+    azclientid,
+    azclientsecret,
+    aztenantid,
+):
+    """Generate local NetCDF weights file for regridding a target climate dataset
+
+    Note, the output weights file is only written to the local disk. See
+    https://xesmf.readthedocs.io/ for details on requirements for `x` with
+    different methods.
+    """
+
+    # Configure storage while we have access to users configurations.
+    storage = AzureZarr(
+        account_name=azstorageaccount,
+        account_key=azstoragekey,
+        client_id=azclientid,
+        client_secret=azclientsecret,
+        tenant_id=aztenantid,
+    )
+    services.build_weights(str(x), str(method), storage=storage, outpath=str(outpath))

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -1,15 +1,25 @@
 """Commandline interface to the application.
 """
 
+import logging
 import click
 import dodola.services as services
 from dodola.repository import AzureZarr
 
 
+logger = logging.getLogger(__name__)
+
+
 # Main entry point
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
-def dodola_cli():
+@click.option("--debug/--no-debug", default=False, envvar="DODOLA_DEBUG")
+def dodola_cli(debug):
     """GCM bias-correction and downscaling"""
+    loglevel = logging.INFO
+    if debug:
+        loglevel = logging.DEBUG
+
+    logging.basicConfig(level=loglevel)
 
 
 @dodola_cli.command(help="Bias-correct GCM on observations")

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -29,8 +29,6 @@ def bias_correct_bcsd(
         variable name used in training data
     out_variable : str
         variable name used in downscaled output
-    ds_predicted : Dataset
-        bias corrected future model data
     """
 
     # note that time_grouper='daily_nasa-nex' is what runs the

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -41,14 +41,16 @@ def bias_correct_bcsd(
     return ds_predicted
 
 
-def build_xesmf_weights_file(x, method, filename=None):
-    """Build ESMF weights file for regridding x to a global 1x1 grid
+def build_xesmf_weights_file(x, method, target_resolution, filename=None):
+    """Build ESMF weights file for regridding x to a global grid
 
     Parameters
     ----------
     x : xr.Dataset
     method : str
         Method of regridding. Passed to ``xesmf.Regridder``.
+    target_resolution: float
+        Decimal-degree resolution of global grid to regrid to.
     filename : optional
         Local path to output netCDF weights file.
 
@@ -57,5 +59,10 @@ def build_xesmf_weights_file(x, method, filename=None):
     outfilename : str
         Path to resulting weights file.
     """
-    out = xe.Regridder(x, xe.util.grid_global(1, 1), method=method, filename=filename)
+    out = xe.Regridder(
+        x,
+        xe.util.grid_global(target_resolution, target_resolution),
+        method=method,
+        filename=filename,
+    )
     return str(out.filename)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -4,6 +4,7 @@ Math stuff and business logic goes here. This is the "business logic".
 """
 
 from skdownscale.pointwise_models import PointWiseDownscaler, BcsdTemperature
+import xesmf as xe
 
 # Break this down into a submodule(s) if needed.
 # Assume data input here is generally clean and valid.
@@ -40,3 +41,23 @@ def bias_correct_bcsd(
     predicted = model.predict(gcm_predict_ds[train_variable]).load()
     ds_predicted = predicted.to_dataset(name=out_variable)
     return ds_predicted
+
+
+def build_xesmf_weights_file(x, method, filename=None):
+    """Build ESMF weights file for regridding x to a global 1x1 grid
+
+    Parameters
+    ----------
+    x : xr.Dataset
+    method : str
+        Method of regridding. Passed to ``xesmf.Regridder``.
+    filename : optional
+        Local path to output netCDF weights file.
+
+    Returns
+    -------
+    outfilename : str
+        Path to resulting weights file.
+    """
+    out = xe.Regridder(x, xe.util.grid_global(1, 1), method=method, filename=filename)
+    return str(out.filename)

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -4,8 +4,12 @@ These are abstractions to isolate most of the data layer.
 """
 
 import abc
+import logging
 from adlfs import AzureBlobFileSystem
 from xarray import open_zarr
+
+
+logger = logging.getLogger(__name__)
 
 
 class RepositoryABC(abc.ABC):
@@ -84,7 +88,9 @@ class AzureZarr(RepositoryABC):
         -------
         xr.Dataset
         """
-        return open_zarr(self.fs.get_mapper(url_or_path))
+        x = open_zarr(self.fs.get_mapper(url_or_path))
+        logger.info(f"Read {url_or_path}")
+        return x
 
     def write(self, url_or_path, x):
         """Write Dataset to Zarr file in storage
@@ -99,6 +105,7 @@ class AzureZarr(RepositoryABC):
         x : xr.Dataset
         """
         x.to_zarr(self.fs.get_mapper(url_or_path), mode="w", compute=True)
+        logger.info(f"Written {url_or_path}")
 
 
 class FakeRepository(RepositoryABC):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -1,7 +1,10 @@
 """Used by the CLI or any UI to deliver services to our lovely users
 """
-
+import logging
 from dodola.core import bias_correct_bcsd, build_xesmf_weights_file
+
+
+logger = logging.getLogger(__name__)
 
 
 def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage):
@@ -26,6 +29,7 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage
     storage : RepositoryABC-like
         Storage abstraction for data IO.
     """
+    logger.info("Correcting bias")
     gcm_training_ds = storage.read(x_train)
     obs_training_ds = storage.read(y_train)
     gcm_predict_ds = storage.read(x)
@@ -36,6 +40,7 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage
     )
 
     storage.write(out, bias_corrected_ds)
+    logger.info("Bias corrected")
 
 
 def build_weights(x, method, storage, outpath=None):
@@ -52,8 +57,10 @@ def build_weights(x, method, storage, outpath=None):
     outpath : optional
         Local file path name to write regridding weights file to.
     """
+    logger.info("Building weights")
     ds = storage.read(x)
     build_xesmf_weights_file(ds, method=method, filename=outpath)
+    logger.info("Weights built")
 
 
 def disaggregate(x, weights, out, repo):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -1,7 +1,7 @@
 """Used by the CLI or any UI to deliver services to our lovely users
 """
 
-from dodola.core import bias_correct_bcsd
+from dodola.core import bias_correct_bcsd, build_xesmf_weights_file
 
 
 def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage):
@@ -38,9 +38,22 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage
     storage.write(out, bias_corrected_ds)
 
 
-def generate_weights(x, out, repo):
-    """This is just an example. Please replace or delete."""
-    raise NotImplementedError
+def generate_weights(x, method, storage, outfile=None):
+    """Generate local NetCDF weights file for regridding climate data
+
+    Parameters
+    ----------
+    x : str
+        Storage URL to input xr.Dataset that will be regridded.
+    method : str
+        Method of regridding. Passed to ``xesmf.Regridder``.
+    storage : RepositoryABC-like
+        Storage abstraction for data IO.
+    outfile : optional
+        Local file path name to write regridding weights file to.
+    """
+    ds = storage.read(x)
+    weights_path = build_xesmf_weights_file(ds, method=method, filename=outfile)
 
 
 def disaggregate(x, weights, out, repo):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -38,7 +38,7 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage
     storage.write(out, bias_corrected_ds)
 
 
-def generate_weights(x, method, storage, outfile=None):
+def build_weights(x, method, storage, outpath=None):
     """Generate local NetCDF weights file for regridding climate data
 
     Parameters
@@ -49,11 +49,11 @@ def generate_weights(x, method, storage, outfile=None):
         Method of regridding. Passed to ``xesmf.Regridder``.
     storage : RepositoryABC-like
         Storage abstraction for data IO.
-    outfile : optional
+    outpath : optional
         Local file path name to write regridding weights file to.
     """
     ds = storage.read(x)
-    weights_path = build_xesmf_weights_file(ds, method=method, filename=outfile)
+    weights_path = build_xesmf_weights_file(ds, method=method, filename=outpath)
 
 
 def disaggregate(x, weights, out, repo):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -53,7 +53,7 @@ def build_weights(x, method, storage, outpath=None):
         Local file path name to write regridding weights file to.
     """
     ds = storage.read(x)
-    weights_path = build_xesmf_weights_file(ds, method=method, filename=outpath)
+    build_xesmf_weights_file(ds, method=method, filename=outpath)
 
 
 def disaggregate(x, weights, out, repo):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -43,7 +43,7 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage
     logger.info("Bias corrected")
 
 
-def build_weights(x, method, storage, outpath=None):
+def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
     """Generate local NetCDF weights file for regridding climate data
 
     Parameters
@@ -52,6 +52,8 @@ def build_weights(x, method, storage, outpath=None):
         Storage URL to input xr.Dataset that will be regridded.
     method : str
         Method of regridding. Passed to ``xesmf.Regridder``.
+    target_resolution : float, optional
+        Decimal-degree resolution of global grid to regrid to.
     storage : RepositoryABC-like
         Storage abstraction for data IO.
     outpath : optional
@@ -59,7 +61,9 @@ def build_weights(x, method, storage, outpath=None):
     """
     logger.info("Building weights")
     ds = storage.read(x)
-    build_xesmf_weights_file(ds, method=method, filename=outpath)
+    build_xesmf_weights_file(
+        ds, method=method, target_resolution=target_resolution, filename=outpath
+    )
     logger.info("Weights built")
 
 

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -5,7 +5,9 @@ import dodola.services
 
 
 @pytest.mark.parametrize(
-    "subcmd", [None, "biascorrect"], ids=("--help", "biascorrect --help")
+    "subcmd",
+    [None, "biascorrect", "buildweights"],
+    ids=("--help", "biascorrect --help", "buildweights --help"),
 )
 def test_cli_helpflags(subcmd):
     """Test that CLI commands don't throw Error if given --help flag"""

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import xarray as xr
-from dodola.services import bias_correct, generate_weights
+from dodola.services import bias_correct, build_weights
 from dodola.repository import FakeRepository
 
 
@@ -84,8 +84,8 @@ def test_bias_correct_basic_call():
     )
 
 
-def test_generate_weights(tmpdir):
-    """Test that services.generate_weights produces a weights file"""
+def test_build_weights(tmpdir):
+    """Test that services.build_weights produces a weights file"""
     # Output to tmp dir so we cleanup & don't clobber existing files...
     weightsfile = tmpdir.join("a_file_path_weights.nc")
 
@@ -106,8 +106,8 @@ def test_generate_weights(tmpdir):
         }
     )
 
-    generate_weights(
-        "a_file_path", method="bilinear", outfile=weightsfile, storage=fakestorage
+    build_weights(
+        "a_file_path", method="bilinear", storage=fakestorage, outpath=weightsfile
     )
     # Test that weights file is actually created where we asked.
     assert weightsfile.exists()

--- a/environment.yaml
+++ b/environment.yaml
@@ -10,6 +10,7 @@ dependencies:
 - pytest
 - python=3.8
 - xarray
+- xesmf
 - bottleneck
 - zarr
 - pip:


### PR DESCRIPTION
This is a rough pass at weights-file building functionality. I also set up logging.

This adds:

- CLI interface: `dodola buildweights <inputfile_url> -m "bilinear" --output /new-weightsfile.nc`
- `build_weights()` in `dodola/services.py`.
- `build_xesmf_weights_file()` in `dodola/core.py` - Does the work, returns the weights file path.
- `xesmf` is now a dependency.
- Tests to check that service outputs a file where we tell it to. Checks that the CLI doesn't give an error if someone tries to run `dodola buildweights --help`.
- We now have services logging so we have a basic record of whats happening, when. Trying to keep it simple and see how it goes.

You can pick whichever regridding method you want and this is passed on to `xesmf`. This also lets `xesmf` handle errors and input checks for the weights file creation, etc.

close #9, close #14

This PR includes a minor docstr fix.