### PR TITLE
add QDM as bias correction option

### DIFF
--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -22,6 +22,7 @@ def dodola_cli():
 )
 @click.argument("out", required=True)
 @click.argument("outvariable", required=True)
+@click.argument("method", required=True)
 @click.option(
     "--azstorageaccount",
     default=None,
@@ -59,13 +60,14 @@ def biascorrect(
     ytrain,
     out,
     outvariable,
+    method,
     azstorageaccount,
     azstoragekey,
     azclientid,
     azclientsecret,
     aztenantid,
 ):
-    """Bias-correct GCM (x) to 'out' based on model (xtrain), obs (ytrain)"""
+    """Bias-correct GCM (x) to 'out' based on model (xtrain), obs (ytrain) using (method)"""
 
     # Configure storage while we have access to users configurations.
     storage = AzureZarr(
@@ -83,4 +85,5 @@ def biascorrect(
         storage,
         train_variable=trainvariable,
         out_variable=outvariable,
+        method=method,
     )

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -4,17 +4,24 @@ Math stuff and business logic goes here. This is the "business logic".
 """
 
 from skdownscale.pointwise_models import PointWiseDownscaler, BcsdTemperature
+from xclim import sdba
 
 # Break this down into a submodule(s) if needed.
 # Assume data input here is generally clean and valid.
 
 
-def bias_correct_bcsd(
-    gcm_training_ds, obs_training_ds, gcm_predict_ds, train_variable, out_variable
+def apply_bias_correction(
+    gcm_training_ds,
+    obs_training_ds,
+    gcm_predict_ds,
+    train_variable,
+    out_variable,
+    method,
 ):
 
-    """Bias correct input model data using BCSD method,
-       using either monthly or +/- 15 day time grouping.
+    """Bias correct input model data using specified method,
+       using either monthly or +/- 15 day time grouping. Currently
+       BCSD and QDM methods are supported.
 
     Parameters
     ----------
@@ -28,15 +35,26 @@ def bias_correct_bcsd(
         variable name used in training data
     out_variable : str
         variable name used in downscaled output
+    method : str
+        method to be used in the applied bias correction
     ds_predicted : Dataset
         bias corrected future model data
     """
-
-    # note that time_grouper='daily_nasa-nex' is what runs the
-    # NASA-NEX version of daily BCSD
-    # TO-DO: switch to NASA-NEX version once tests pass
-    model = PointWiseDownscaler(BcsdTemperature(return_anoms=False))
-    model.fit(gcm_training_ds[train_variable], obs_training_ds[train_variable])
-    predicted = model.predict(gcm_predict_ds[train_variable]).load()
+    if method == "BCSD":
+        # note that time_grouper='daily_nasa-nex' is what runs the
+        # NASA-NEX version of daily BCSD
+        # TO-DO: switch to NASA-NEX version once tests pass
+        model = PointWiseDownscaler(BcsdTemperature(return_anoms=False))
+        model.fit(gcm_training_ds[train_variable], obs_training_ds[train_variable])
+        predicted = model.predict(gcm_predict_ds[train_variable]).load()
+    elif method == "QDM":
+        # instantiates a grouper class that groups by day of the year
+        # centered window: +/-15 day group
+        group = sdba.Grouper("time.dayofyear", window=31)
+        model = sdba.adjustment.QuantileDeltaMapping(group=group, kind="+")
+        model.train(gcm_training_ds[train_variable], obs_training_ds[train_variable])
+        predicted = model.adjust(gcm_predict_ds[train_variable])
+    else:
+        raise ValueError("this method is not yet supported")
     ds_predicted = predicted.to_dataset(name=out_variable)
     return ds_predicted

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -57,7 +57,7 @@ def apply_bias_correction(
         model.train(gcm_training_ds[train_variable], obs_training_ds[train_variable])
         predicted = model.adjust(gcm_predict_ds[train_variable])
     else:
-        raise ValueError("this method is not yet supported")
+        raise ValueError("this method is not supported")
     ds_predicted = predicted.to_dataset(name=out_variable)
     return ds_predicted
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -36,7 +36,7 @@ def apply_bias_correction(
         variable name used in training data
     out_variable : str
         variable name used in downscaled output
-    method : str
+    method : {"BCSD", "QDM"}
         method to be used in the applied bias correction
     ds_predicted : Dataset
         bias corrected future model data

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -6,7 +6,6 @@ from dodola.core import apply_bias_correction, build_xesmf_weights_file
 logger = logging.getLogger(__name__)
 
 
-
 def bias_correct(
     x, x_train, train_variable, y_train, out, out_variable, method, storage
 ):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -1,10 +1,12 @@
 """Used by the CLI or any UI to deliver services to our lovely users
 """
 
-from dodola.core import bias_correct_bcsd
+from dodola.core import apply_bias_correction
 
 
-def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage):
+def bias_correct(
+    x, x_train, train_variable, y_train, out, out_variable, method, storage
+):
     """Bias correct input model data with IO to storage
 
     Parameters
@@ -23,6 +25,8 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage
         Storage URL to write bias-corrected output to.
     out_variable : str
         Variable name used as output variable name.
+    method : str
+        Bias correction method to be used.
     storage : RepositoryABC-like
         Storage abstraction for data IO.
     """
@@ -31,8 +35,13 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, storage
     gcm_predict_ds = storage.read(x)
 
     # This is all made up demo. Just get the output dataset the user expects.
-    bias_corrected_ds = bias_correct_bcsd(
-        gcm_training_ds, obs_training_ds, gcm_predict_ds, train_variable, out_variable
+    bias_corrected_ds = apply_bias_correction(
+        gcm_training_ds,
+        obs_training_ds,
+        gcm_predict_ds,
+        train_variable,
+        out_variable,
+        method,
     )
 
     storage.write(out, bias_corrected_ds)

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -4,7 +4,6 @@
 import numpy as np
 import pytest
 import xarray as xr
-import pytest
 from xesmf.data import wave_smooth
 from xesmf.util import grid_global
 from dodola.services import bias_correct, build_weights

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -32,8 +32,24 @@ def _datafactory(x, start_time="1950-01-01"):
     return out
 
 
-@pytest.mark.parametrize("method", ["QDM", "BCSD"])
-def test_bias_correct_basic_call(method):
+@pytest.mark.parametrize(
+    "method, expected_head, expected_tail",
+    [
+        pytest.param(
+            "QDM",
+            np.array([4.0, 4.008609, 4.0172155, 4.0258169, 4.0344106]),
+            np.array([3.9655894, 3.9741831, 3.9827845, 3.991391, 4.0]),
+            id="QDM head/tail",
+        ),
+        pytest.param(
+            "BCSD",
+            np.array([-0.08129293, -0.07613746, -0.0709855, -0.0658377, -0.0606947]),
+            np.array([0.0520793, 0.06581804, 0.07096781, 0.07612168, 0.08127902]),
+            id="BCSD head/tail",
+        ),
+    ],
+)
+def test_bias_correct_basic_call(method, expected_head, expected_tail):
     """Simple integration test of bias_correct service"""
     # Setup input data.
     n_years = 10
@@ -77,25 +93,13 @@ def test_bias_correct_basic_call(method):
     # We can't just test for removal of bias here since quantile mapping
     # and adding in trend are both components of bias correction,
     # so testing head and tail values instead
-    if method == "BCSD":
-        head_vals = np.array(
-            [-0.08129293, -0.07613746, -0.0709855, -0.0658377, -0.0606947]
-        )
-        tail_vals = np.array(
-            [0.0520793, 0.06581804, 0.07096781, 0.07612168, 0.08127902]
-        )
-    elif method == "QDM":
-        head_vals = np.array([4.0, 4.008609, 4.0172155, 4.0258169, 4.0344106])
-        tail_vals = np.array([3.9655894, 3.9741831, 3.9827845, 3.991391, 4.0])
-    else:
-        raise ValueError("this method has not yet been tested")
     np.testing.assert_almost_equal(
         fakestorage.storage[output_key]["fakevariable"].squeeze(drop=True).values[:5],
-        head_vals,
+        expected_head,
     )
     np.testing.assert_almost_equal(
         fakestorage.storage[output_key]["fakevariable"].squeeze(drop=True).values[-5:],
-        tail_vals,
+        expected_tail,
     )
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -2,6 +2,7 @@
 """
 
 import numpy as np
+import pytest
 import xarray as xr
 from dodola.services import bias_correct
 from dodola.repository import FakeRepository
@@ -28,8 +29,8 @@ def _datafactory(x, start_time="1950-01-01"):
     )
     return out
 
-
-def test_bias_correct_basic_call():
+@pytest.mark.parametrize("method", ["QDM", "BCSD"])
+def test_bias_correct_basic_call(method):
     """Simple integration test of bias_correct service"""
     # Setup input data.
     n_years = 10
@@ -43,9 +44,6 @@ def test_bias_correct_basic_call():
     y_train = _datafactory(ts)
     # Yes, we're testing and training on the same data...
     x_test = x_train.copy(deep=True)
-
-    # pick test method
-    method = "BCSD"
 
     output_key = "test_output"
     training_model_key = "x_train"
@@ -76,8 +74,14 @@ def test_bias_correct_basic_call():
     # We can't just test for removal of bias here since quantile mapping
     # and adding in trend are both components of bias correction,
     # so testing head and tail values instead
-    head_vals = np.array([-0.08129293, -0.07613746, -0.0709855, -0.0658377, -0.0606947])
-    tail_vals = np.array([0.0520793, 0.06581804, 0.07096781, 0.07612168, 0.08127902])
+    if method == "BCSD":
+        head_vals = np.array([-0.08129293, -0.07613746, -0.0709855, -0.0658377, -0.0606947])
+        tail_vals = np.array([0.0520793, 0.06581804, 0.07096781, 0.07612168, 0.08127902])
+    elif method == "QDM":
+        head_vals = np.array([4., 4.008609 , 4.0172155, 4.0258169, 4.0344106])
+        tail_vals = np.array([3.9655894, 3.9741831, 3.9827845, 3.991391 , 4.])
+    else: 
+        raise ValueError("this method has not yet been tested")
     np.testing.assert_almost_equal(
         fakestorage.storage[output_key]["fakevariable"].squeeze(drop=True).values[:5],
         head_vals,

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -29,6 +29,7 @@ def _datafactory(x, start_time="1950-01-01"):
     )
     return out
 
+
 @pytest.mark.parametrize("method", ["QDM", "BCSD"])
 def test_bias_correct_basic_call(method):
     """Simple integration test of bias_correct service"""
@@ -75,12 +76,16 @@ def test_bias_correct_basic_call(method):
     # and adding in trend are both components of bias correction,
     # so testing head and tail values instead
     if method == "BCSD":
-        head_vals = np.array([-0.08129293, -0.07613746, -0.0709855, -0.0658377, -0.0606947])
-        tail_vals = np.array([0.0520793, 0.06581804, 0.07096781, 0.07612168, 0.08127902])
+        head_vals = np.array(
+            [-0.08129293, -0.07613746, -0.0709855, -0.0658377, -0.0606947]
+        )
+        tail_vals = np.array(
+            [0.0520793, 0.06581804, 0.07096781, 0.07612168, 0.08127902]
+        )
     elif method == "QDM":
-        head_vals = np.array([4., 4.008609 , 4.0172155, 4.0258169, 4.0344106])
-        tail_vals = np.array([3.9655894, 3.9741831, 3.9827845, 3.991391 , 4.])
-    else: 
+        head_vals = np.array([4.0, 4.008609, 4.0172155, 4.0258169, 4.0344106])
+        tail_vals = np.array([3.9655894, 3.9741831, 3.9827845, 3.991391, 4.0])
+    else:
         raise ValueError("this method has not yet been tested")
     np.testing.assert_almost_equal(
         fakestorage.storage[output_key]["fakevariable"].squeeze(drop=True).values[:5],

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -45,7 +45,7 @@ def test_bias_correct_basic_call():
     x_test = x_train.copy(deep=True)
 
     # pick test method
-    method = "BCSD" 
+    method = "BCSD"
 
     output_key = "test_output"
     training_model_key = "x_train"

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -44,6 +44,9 @@ def test_bias_correct_basic_call():
     # Yes, we're testing and training on the same data...
     x_test = x_train.copy(deep=True)
 
+    # pick test method
+    method = "BCSD" 
+
     output_key = "test_output"
     training_model_key = "x_train"
     training_obs_key = "y_train"
@@ -66,6 +69,7 @@ def test_bias_correct_basic_call():
         y_train=training_obs_key,
         out=output_key,
         out_variable="fakevariable",
+        method=method,
         storage=fakestorage,
     )
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,3 +14,4 @@ dependencies:
 - zarr
 - pip:
   - git+https://github.com/dgergel/xsd@pointwisedownscaler_interimfix
+  - xclim

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
 - xarray
 - xesmf
 - bottleneck
+- xclim
 - zarr
 - pip:
   - git+https://github.com/dgergel/xsd@pointwisedownscaler_interimfix
-  - xclim


### PR DESCRIPTION
This PR updates the core bias correction code to include the QDM method (Cannon et al., 2015) by specifying the bias correction method at the CLI interface. 

Specifically, it adds: 
- CLI interface: `dodola biascorrect <method> <methodstring> <inputURL> <modeltrainingURL> <obstrainingURL> <outputURL>`
- updates `bias_correct_bcsd` to `apply_bias_correction` to support both BCSD and QDM by including a `method` argument
- updates `apply_bias_correction` to include QDM code 
- `xclim` is now a dependency
- testing is still with BCSD since we don't have a way to test both methods currently 

closes #18 