### PR TITLE
Add rechunker service, refactor repository.py to simplify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM continuumio/miniconda3:4.9.2
 
 ENV PATH /opt/conda/bin:$PATH
+RUN conda install mamba -c conda-forge && conda clean --all
 
 # Copy only app requirements to cache dependencies
 RUN mkdir /opt/dodola
 COPY environment.yaml /opt/dodola/environment.yaml
-RUN conda env update -n base -f /opt/dodola/environment.yaml \
-    && conda clean --all
+RUN mamba env update -n base -f /opt/dodola/environment.yaml \
+    && mamba clean --all
 
 COPY . /opt/dodola
 RUN bash -c "pip install -e /opt/dodola"

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -182,3 +182,94 @@ def buildweights(
         storage=storage,
         outpath=str(outpath),
     )
+
+
+@dodola_cli.command(help="Rechunk Zarr store")
+@click.argument("x", required=True)
+@click.option(
+    "--variable",
+    "-v",
+    required=True,
+    help="Variable to rechunk",
+)
+@click.option(
+    "--chunk",
+    "-c",
+    required=True,
+    help="coord=chunksize to rechunk to",
+)
+@click.option(
+    "--maxmemory",
+    "-m",
+    required=True,
+    help="Max memory (bytes) to use for rechunking",
+)
+@click.option(
+    "--outpath",
+    "-o",
+    required=True,
+)
+@click.option(
+    "--azstorageaccount",
+    default=None,
+    envvar="AZURE_STORAGE_ACCOUNT",
+    help="Key-based Azure storage credential",
+)
+@click.option(
+    "--azstoragekey",
+    default=None,
+    envvar="AZURE_STORAGE_KEY",
+    help="Key-based Azure storage credential",
+)
+@click.option(
+    "--azclientid",
+    default=None,
+    envvar="AZURE_CLIENT_ID",
+    help="Service Principal-based Azure storage credential",
+)
+@click.option(
+    "--azclientsecret",
+    default=None,
+    envvar="AZURE_CLIENT_SECRET",
+    help="Service Principal-based Azure storage credential",
+)
+@click.option(
+    "--aztenantid",
+    default=None,
+    envvar="AZURE_TENANT_ID",
+    help="Service Principal-based Azure storage credential",
+)
+def rechunk(
+    x,
+    variable,
+    chunk,
+    maxmemory,
+    outpath,
+    azstorageaccount,
+    azstoragekey,
+    azclientid,
+    azclientsecret,
+    aztenantid,
+):
+    """Rechunk Zarr store"""
+
+    # Configure storage while we have access to users configurations.
+    storage = adl_repository(
+        account_name=azstorageaccount,
+        account_key=azstoragekey,
+        client_id=azclientid,
+        client_secret=azclientsecret,
+        tenant_id=aztenantid,
+    )
+
+    # Convert ["k1=1", "k2=2"] into {k1: 1, k2: 2}
+    coord_chunks = {c.split("=")[0]: int(c.split("=")[1]) for c in chunk}
+    target_chunks = {variable: coord_chunks}
+
+    services.rechunk(
+        str(x),
+        target_chunks=target_chunks,
+        out=outpath,
+        max_mem=maxmemory,
+        storage=storage,
+    )

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -4,7 +4,7 @@
 import logging
 import click
 import dodola.services as services
-from dodola.repository import AzureZarr
+from dodola.repository import adl_repository
 
 
 logger = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ def biascorrect(
     """Bias-correct GCM (x) to 'out' based on model (xtrain), obs (ytrain) using (method)"""
 
     # Configure storage while we have access to users configurations.
-    storage = AzureZarr(
+    storage = adl_repository(
         account_name=azstorageaccount,
         account_key=azstoragekey,
         client_id=azclientid,
@@ -168,7 +168,7 @@ def buildweights(
     """
 
     # Configure storage while we have access to users configurations.
-    storage = AzureZarr(
+    storage = adl_repository(
         account_name=azstorageaccount,
         account_key=azstoragekey,
         client_id=azclientid,

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -205,7 +205,7 @@ def buildweights(
     help="Max memory (bytes) to use for rechunking",
 )
 @click.option(
-    "--outpath",
+    "--out",
     "-o",
     required=True,
 )
@@ -244,7 +244,7 @@ def rechunk(
     variable,
     chunk,
     maxmemory,
-    outpath,
+    out,
     azstorageaccount,
     azstoragekey,
     azclientid,
@@ -269,7 +269,7 @@ def rechunk(
     services.rechunk(
         str(x),
         target_chunks=target_chunks,
-        out=outpath,
+        out=out,
         max_mem=maxmemory,
         storage=storage,
     )

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -3,10 +3,6 @@
 Math stuff and business logic goes here. This is the "business logic".
 """
 
-import os
-from tempfile import TemporaryDirectory
-
-from rechunker import rechunk
 from skdownscale.pointwise_models import PointWiseDownscaler, BcsdTemperature
 import xarray as xr
 from xclim import sdba
@@ -92,40 +88,3 @@ def build_xesmf_weights_file(x, method, target_resolution, filename=None):
         filename=filename,
     )
     return str(out.filename)
-
-
-def rechunk_ds(ds, target_chunks, max_mem):
-    """Quickly (re)chunk a Dataset to specification
-
-    Note, this rechunks the input into a Zarr store on the local disk. Be sure
-    disk volume is available for this operation.
-
-    Parameters
-    ----------
-    ds : xr.Dataset
-    target_chunks : dict
-        A dict of dicts. Top-level dict key maps variables name in `ds` to an
-        inner dict {coordinate_name: chunk_size} mapping showing how data is
-        to be rechunked.
-    max_mem : int or str
-        Maximum memory to use for rechunking (bytes).
-
-    Returns
-    -------
-    out : xr.Dataset
-    """
-    max_mem = str(max_mem)  # To work around bug in rechunker.
-    # Using tempdir for isolation/cleanup as rechunker dumps zarr files to disk.
-    with TemporaryDirectory() as tmpdir:
-        rechunkedzarr_path = os.path.join(tmpdir, "rechunk_out.zarr")
-        tmpzarr_path = os.path.join(tmpdir, "rechunk_tmp.zarr")
-        plan = rechunk(
-            ds,
-            target_chunks=target_chunks,
-            target_store=rechunkedzarr_path,
-            temp_store=tmpzarr_path,
-            max_mem=max_mem,
-        )
-        plan.execute()
-        out = xr.open_zarr(rechunkedzarr_path).load()
-    return out

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -95,7 +95,7 @@ def build_xesmf_weights_file(x, method, target_resolution, filename=None):
 
 
 def rechunk_ds(ds, target_chunks, max_mem):
-    """Quickly (re)chunk a Dataset to specification.
+    """Quickly (re)chunk a Dataset to specification
 
     Note, this rechunks the input into a Zarr store on the local disk. Be sure
     disk volume is available for this operation.

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -19,9 +19,18 @@ class _ZarrRepo:
     external packages that couple directly with `fsspec` to stream output
     immediately into storage.
 
+    This is commonly instantiated through ``adl_repository``, or for testing
+    with ``memory_repository``.
+
     Parameters
     ----------
     fs : fsspec.AbstractFileSystem-like
+
+    See Also
+    --------
+    adl_repository: Instantiate a Zarr data repo using Azure Datalake Gen. 2 as backend
+    memory_repository: Instantiate a Zarr data repo in memory
+
     """
 
     def __init__(self, fs):
@@ -33,7 +42,7 @@ class _ZarrRepo:
         Parameters
         ----------
         url_or_path : str
-            Location Zarr store to read.
+            Location of Zarr store to read.
 
         Returns
         -------
@@ -82,7 +91,7 @@ def adl_repository(
     client_secret=None,
     tenant_id=None,
 ):
-    """Instantiate a for Zarr data repo using Azure Datalake Gen. 2 as backend
+    """Instantiate a Zarr data repo using Azure Datalake Gen. 2 as backend
 
     To authenticate with storage must pass in `account_name` and
     `account_key` for key-based authentication or `client_id`, `client_secret`,
@@ -114,7 +123,7 @@ def adl_repository(
 
 
 def memory_repository(storage=None):
-    """Instantiate a ZarrRepo in memory
+    """Instantiate a Zarr data repo in memory
 
     This is most commonly used for testing. Keep in mind that all instances
     share memory globally.

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -10,10 +10,10 @@ from xarray import open_zarr
 logger = logging.getLogger(__name__)
 
 
-class ZarrRepo:
+class _ZarrRepo:
     """Puts a simple read-Dataset/write-Zarr interface over fsspec-like storage
 
-    This puts a basic read/write repository interface pattern over a file
+    This puts a basic read/write repository pattern over a file
     system to abstract-away the data layer. Aside from the ``read()``
     and ``write()`` methods, the additional ``get_mapper()`` method is for
     external packages that couple directly with `fsspec` to stream output
@@ -99,9 +99,9 @@ def adl_repository(
 
     Returns
     -------
-    repo : dodola.repository.ZarrRepo
+    repo : dodola.repository._ZarrRepo
     """
-    repo = ZarrRepo(
+    repo = _ZarrRepo(
         fs=AzureBlobFileSystem(
             account_name=account_name,
             account_key=account_key,
@@ -126,9 +126,9 @@ def memory_repository(storage=None):
 
     Returns
     -------
-    repo : dodola.repository.ZarrRepo
+    repo : dodola.repository._ZarrRepo
     """
-    repo = ZarrRepo(fs=MemoryFileSystem())
+    repo = _ZarrRepo(fs=MemoryFileSystem())
     for k, v in storage.items():
         repo.write(k, v)
     return repo

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -1,55 +1,93 @@
-"""Abstract Repository objects to access stored climate model data.
-
-These are abstractions to isolate most of the data layer.
+"""Objects to read and write stored climate model data.
 """
 
-import abc
 import logging
 from adlfs import AzureBlobFileSystem
+from fsspec.implementations.memory import MemoryFileSystem
 from xarray import open_zarr
 
 
 logger = logging.getLogger(__name__)
 
 
-class RepositoryABC(abc.ABC):
-    """ABC for a basic Repository pattern"""
+class ZarrRepo:
+    """Puts a simple read-Dataset/write-Zarr interface over fsspec-like storage
 
-    @abc.abstractmethod
+    This puts a basic read/write repository interface pattern over a file
+    system to abstract-away the data layer. Aside from the ``read()``
+    and ``write()`` methods, the additional ``get_mapper()`` method is for
+    external packages that couple directly with `fsspec` to stream output
+    immediately into storage.
+
+    Parameters
+    ----------
+    fs : fsspec.AbstractFileSystem-like
+    """
+
+    def __init__(self, fs):
+        self._fs = fs
+
     def read(self, url_or_path):
-        """Read xr.Dataset from storage
+        """Read Dataset from Zarr store
 
         Parameters
         ----------
         url_or_path : str
-            Location (e.g. URL or path) of data to read from storage.
+            Location Zarr store to read.
 
         Returns
         -------
         xr.Dataset
         """
+        x = open_zarr(self.get_mapper(url_or_path))
+        logger.info(f"Read {url_or_path}")
+        return x
 
-    @abc.abstractmethod
     def write(self, url_or_path, x):
-        """Write xr.Dataset, x, to storage
+        """Write Dataset to Zarr store
+
+        This opens Zarr store with mode "w" and is called with with
+        ``compute=True``, so any lazy computations will be completed.
 
         Parameters
         ----------
         url_or_path : str
-            Location (e.g. URL or path) of data to read from storage.
+            Location to write Zarr store to.
         x : xr.Dataset
-            Data to store in repository.
         """
+        x.to_zarr(self.get_mapper(url_or_path), mode="w", compute=True)
+        logger.info(f"Written {url_or_path}")
+
+    def get_mapper(self, root, check=False, create=False):
+        """Get fsspec.FSMap from wrapped FileSystemAbstraction
+
+        Parameters
+        ----------
+        root : str
+        check : bool
+            Do touch at storage to check for write access.
+        create : bool
+
+        Returns
+        -------
+        out : fsspec.FSMap
+        """
+        return self._fs.get_mapper(root, check=check, create=create)
 
 
-class AzureZarr(RepositoryABC):
-    """Azure storage for Zarr data repository.
+def adl_repository(
+    account_name=None,
+    account_key=None,
+    client_id=None,
+    client_secret=None,
+    tenant_id=None,
+):
+    """Instantiate a for Zarr data repo using Azure Datalake Gen. 2 as backend
 
-    To authenticate with storage, must initialize with `account_name` and
-    `account_key` for key-based authentication or `client_id`,
-    `client_secret`, and `tenant_id` for authentication with service principal
-    credentials. Initializing arguments are passed to
-    ``adlfs.AzureBlobFileSystem``.
+    To authenticate with storage must pass in `account_name` and
+    `account_key` for key-based authentication or `client_id`, `client_secret`,
+    and `tenant_id` for authentication with service principal
+    credentials. Initializing arguments are passed to ``adlfs.AzureBlobFileSystem``.
 
     Parameters
     ----------
@@ -58,76 +96,39 @@ class AzureZarr(RepositoryABC):
     client_id : str or None, optional
     client_secret : str or None, optional
     tenant_id : str or None, optional
-    """
 
-    def __init__(
-        self,
-        account_name=None,
-        account_key=None,
-        client_id=None,
-        client_secret=None,
-        tenant_id=None,
-    ):
-        self.fs = AzureBlobFileSystem(
+    Returns
+    -------
+    repo : dodola.repository.ZarrRepo
+    """
+    repo = ZarrRepo(
+        fs=AzureBlobFileSystem(
             account_name=account_name,
             account_key=account_key,
             client_id=client_id,
             client_secret=client_secret,
             tenant_id=tenant_id,
         )
-
-    def read(self, url_or_path):
-        """Read Dataset from Zarr file in storage
-
-        Parameters
-        ----------
-        url_or_path : str
-            URL of Zarr data in Azure storage.
-
-        Returns
-        -------
-        xr.Dataset
-        """
-        x = open_zarr(self.fs.get_mapper(url_or_path))
-        logger.info(f"Read {url_or_path}")
-        return x
-
-    def write(self, url_or_path, x):
-        """Write Dataset to Zarr file in storage
-
-        This opens Zarr storage with mode "w" and is called with with
-        ``compute=True``, so any lazy computations will be completed.
-
-        Parameters
-        ----------
-        url_or_path : str
-            URL of Zarr data to write to.
-        x : xr.Dataset
-        """
-        x.to_zarr(self.fs.get_mapper(url_or_path), mode="w", compute=True)
-        logger.info(f"Written {url_or_path}")
+    )
+    return repo
 
 
-class FakeRepository(RepositoryABC):
-    """Simple in-memory repository for testing
+def memory_repository(storage=None):
+    """Instantiate a ZarrRepo in memory
 
-    This simply puts a Repository interface over a dict.
+    This is most commonly used for testing. Keep in mind that all instances
+    share memory globally.
 
     Parameters
     ----------
-    storage : mapping or None, optional
-        Optional internal repository state.
+    storage : dict or None, optional
+        Mapping of `{path: data}` to immediately store into memory filesystem.
+
+    Returns
+    -------
+    repo : dodola.repository.ZarrRepo
     """
-
-    def __init__(self, storage=None):
-        self.storage = {}
-        if storage:
-            self.storage = dict(storage)
-
-    def read(self, url_or_path):
-        """Read url_or_path key from repository"""
-        return self.storage[url_or_path]
-
-    def write(self, url_or_path, x):
-        """Write data x to repository at key url_or_path"""
-        self.storage[url_or_path] = x
+    repo = ZarrRepo(fs=MemoryFileSystem())
+    for k, v in storage.items():
+        repo.write(k, v)
+    return repo

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -1,7 +1,7 @@
 """Used by the CLI or any UI to deliver services to our lovely users
 """
 import logging
-from dodola.core import apply_bias_correction, build_xesmf_weights_file
+from dodola.core import apply_bias_correction, build_xesmf_weights_file, rechunk_ds
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +75,27 @@ def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
     logger.info("Weights built")
 
 
-def rechunk(x, weights, out, repo):
-    """This is just an example. Please replace or delete."""
-    raise NotImplementedError
+def rechunk(x, target_chunks, out, max_mem, storage):
+    """Rechunk data
+
+    Parameters
+    ----------
+    x : str
+        Storage URL to input data.
+    target_chunks : dict
+        {coordinate_name: chunk_size} mapping showing how data is to be rechunked.
+    out : str
+        Storage URL to write rechunked output to.
+    max_mem : int or str
+        Maximum memory to use for rechunking (bytes).
+    storage : RepositoryABC-like
+        Storage abstraction for data IO.
+    """
+    logger.info("Rechunking data")
+    ds = storage.read(x)
+    rechunked_ds = rechunk_ds(ds, target_chunks=target_chunks, max_mem=max_mem)
+    storage.write(out, rechunked_ds)
+    logger.info("Data rechunked")
 
 
 def disaggregate(x, weights, out, repo):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -97,7 +97,6 @@ def rechunk(x, target_chunks, out, max_mem, storage):
         Storage abstraction for data IO.
     """
     logger.info("Rechunking data")
-    max_mem = str(max_mem)  # To work around bug in rechunker.
     ds = storage.read(x)
 
     # Using tempdir for isolation/cleanup as rechunker dumps zarr files to disk.

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -111,8 +111,9 @@ def rechunk(x, target_chunks, out, max_mem, storage):
             max_mem=max_mem,
         )
         plan.execute()
+        logger.info(f"Written {out}")
 
-    logger.info("Data rechunked")
+logger.info("Data rechunked")
 
 
 def disaggregate(x, weights, out, repo):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -106,14 +106,14 @@ def rechunk(x, target_chunks, out, max_mem, storage):
         plan = rechunker_rechunk(
             ds,
             target_chunks=target_chunks,
-            target_store=storage.get_mapper(out), # Stream directly into storage.
+            target_store=storage.get_mapper(out),  # Stream directly into storage.
             temp_store=tmpzarr_path,
             max_mem=max_mem,
         )
         plan.execute()
         logger.info(f"Written {out}")
 
-logger.info("Data rechunked")
+    logger.info("Data rechunked")
 
 
 def disaggregate(x, weights, out, repo):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -75,6 +75,11 @@ def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
     logger.info("Weights built")
 
 
+def rechunk(x, weights, out, repo):
+    """This is just an example. Please replace or delete."""
+    raise NotImplementedError
+
+
 def disaggregate(x, weights, out, repo):
     """This is just an example. Please replace or delete."""
     raise NotImplementedError

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -100,17 +100,13 @@ def rechunk(x, target_chunks, out, max_mem, storage):
     max_mem = str(max_mem)  # To work around bug in rechunker.
     ds = storage.read(x)
 
-    # Tightly couple with storage so can stream rechunked file directly
-    # into storage.
-    rechunked_store = storage.get_mapper(out)
-
     # Using tempdir for isolation/cleanup as rechunker dumps zarr files to disk.
     with TemporaryDirectory() as tmpdir:
         tmpzarr_path = os.path.join(tmpdir, "rechunk_tmp.zarr")
         plan = rechunker_rechunk(
             ds,
             target_chunks=target_chunks,
-            target_store=rechunked_store,
+            target_store=storage.get_mapper(out), # Stream directly into storage.
             temp_store=tmpzarr_path,
             max_mem=max_mem,
         )

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -76,14 +76,16 @@ def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
 
 
 def rechunk(x, target_chunks, out, max_mem, storage):
-    """Rechunk data
+    """Rechunk data to specification
 
     Parameters
     ----------
     x : str
         Storage URL to input data.
     target_chunks : dict
-        {coordinate_name: chunk_size} mapping showing how data is to be rechunked.
+        A dict of dicts. Top-level dict key maps variables name in `ds` to an
+        inner dict {coordinate_name: chunk_size} mapping showing how data is
+        to be rechunked.
     out : str
         Storage URL to write rechunked output to.
     max_mem : int or str

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -32,7 +32,7 @@ def bias_correct(
         Variable name used as output variable name.
     method : str
         Bias correction method to be used.
-    storage : RepositoryABC-like
+    storage : dodola.repository._ZarrRepo
         Storage abstraction for data IO.
     """
     logger.info("Correcting bias")
@@ -65,7 +65,7 @@ def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
         Method of regridding. Passed to ``xesmf.Regridder``.
     target_resolution : float, optional
         Decimal-degree resolution of global grid to regrid to.
-    storage : RepositoryABC-like
+    storage : dodola.repository._ZarrRepo
         Storage abstraction for data IO.
     outpath : optional
         Local file path name to write regridding weights file to.
@@ -93,7 +93,7 @@ def rechunk(x, target_chunks, out, max_mem, storage):
         Storage URL to write rechunked output to.
     max_mem : int or str
         Maximum memory to use for rechunking (bytes).
-    storage : RepositoryABC-like
+    storage : dodola.repository._ZarrRepo
         Storage abstraction for data IO.
     """
     logger.info("Rechunking data")

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -7,7 +7,7 @@ import dodola.services
 @pytest.mark.parametrize(
     "subcmd",
     [None, "biascorrect", "buildweights", "rechunk"],
-    ids=("--help", "biascorrect --help", "buildweights --help"),
+    ids=("--help", "biascorrect --help", "buildweights --help", "rechunk --help"),
 )
 def test_cli_helpflags(subcmd):
     """Test that CLI commands don't throw Error if given --help flag"""

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -6,7 +6,7 @@ import dodola.services
 
 @pytest.mark.parametrize(
     "subcmd",
-    [None, "biascorrect", "buildweights"],
+    [None, "biascorrect", "buildweights", "rechunk"],
     ids=("--help", "biascorrect --help", "buildweights --help"),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_repository.py
+++ b/dodola/tests/test_repository.py
@@ -1,14 +1,15 @@
-from dodola.repository import FakeRepository
+from xarray import Dataset
+from dodola.repository import memory_repository
 
 
 def test_fakerepository_read():
-    """Basic test that FakeRepository.read() works"""
-    storage = FakeRepository(storage={"foo": "bar"})
-    assert storage.read(url_or_path="foo") == "bar"
+    """Basic test that memory_repository.read() works"""
+    storage = memory_repository(storage={"foo": Dataset({"bar": 123})})
+    assert storage.read(url_or_path="foo") == Dataset({"bar": 123})
 
 
 def test_fakerepository_write():
-    """Basic test that FakeRepository.write() works"""
-    storage = FakeRepository(storage={"foo": "bar"})
-    storage.write(url_or_path="foo", x="SPAM")
-    assert storage.read(url_or_path="foo") == "SPAM"
+    """Basic test that memory_repository.write() works"""
+    storage = memory_repository(storage={"foo": Dataset({"bar": 321})})
+    storage.write(url_or_path="foo", x=Dataset({"bar": "SPAM"}))
+    assert storage.read(url_or_path="foo") == Dataset({"bar": "SPAM"})

--- a/dodola/tests/test_repository.py
+++ b/dodola/tests/test_repository.py
@@ -2,13 +2,13 @@ from xarray import Dataset
 from dodola.repository import memory_repository
 
 
-def test_fakerepository_read():
+def test_memory_repository_read():
     """Basic test that memory_repository.read() works"""
     storage = memory_repository(storage={"foo": Dataset({"bar": 123})})
     assert storage.read(url_or_path="foo") == Dataset({"bar": 123})
 
 
-def test_fakerepository_write():
+def test_memory_repository_write():
     """Basic test that memory_repository.write() works"""
     storage = memory_repository(storage={"foo": Dataset({"bar": 321})})
     storage.write(url_or_path="foo", x=Dataset({"bar": "SPAM"}))

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -148,4 +148,4 @@ def test_rechunk():
         storage=fakestorage,
     )
 
-    fakestorage.storage["output_ds"]["fakevariable"].chunks == chunks_goal
+    assert fakestorage.read("output_ds")["fakevariable"].chunks == chunks_goal

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -129,7 +129,7 @@ def test_build_weights(regrid_method, tmpdir):
 def test_rechunk():
     """Test that rechunk service rechunks"""
     chunks_goal = {"time": 4, "lon": 1, "lat": 1}
-    in_ds = xr.Dataset(
+    test_ds = xr.Dataset(
         {"fakevariable": (["time", "lon", "lat"], np.ones((4, 4, 4)))},
         coords={
             "time": [1, 2, 3, 4],
@@ -138,8 +138,14 @@ def test_rechunk():
         },
     )
 
-    fakestorage = FakeRepository({"input_ds": in_ds})
+    fakestorage = FakeRepository({"input_ds": test_ds})
 
-    rechunk("input_ds", target_chunks=chunks_goal, out="output_ds", max_mem=256000, storage=fakestorage)
+    rechunk(
+        "input_ds",
+        target_chunks={"fakevariable": chunks_goal},
+        out="output_ds",
+        max_mem=256000,
+        storage=fakestorage,
+    )
 
-    fakestorage.storage["output"]["fakevariable"].chunks == chunks_goal
+    fakestorage.storage["output_ds"]["fakevariable"].chunks == chunks_goal

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -147,5 +147,6 @@ def test_rechunk():
         max_mem=256000,
         storage=fakestorage,
     )
+    actual_chunks = fakestorage.read("output_ds")["fakevariable"].data.chunksize
 
-    assert fakestorage.read("output_ds")["fakevariable"].chunks == chunks_goal
+    assert actual_chunks == tuple(chunks_goal.values())

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,7 +1,6 @@
 name: base
 channels:
 - conda-forge
-- nesii
 dependencies:
 - adlfs
 - click

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,6 +5,7 @@ dependencies:
 - adlfs
 - click
 - cftime
+- fsspec
 - numpy
 - pip
 - pytest

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,6 +13,7 @@ dependencies:
 - rechunker
 - xarray
 - xesmf
+- esmpy=8.0.1=nompi_py38h5410a82_2  # Not direct dep. Dep of xesmf.
 - bottleneck
 - xclim
 - zarr

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,6 +1,7 @@
 name: base
 channels:
 - conda-forge
+- nesii
 dependencies:
 - adlfs
 - click

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,6 +9,7 @@ dependencies:
 - pip
 - pytest
 - python=3.8
+- rechunker
 - xarray
 - xesmf
 - bottleneck


### PR DESCRIPTION
Adds rechunking service via the `rechunker` package. It lets us rechunk a single variable in zarr store.

CLI interface is:

```bash
dodola rechunk path/to/a/store.zarr -v tasmax \
    -c time=31390 \
    -c lat=30 \
    -c lon=30 \
    --maxmemory 113004000 \
    --out path/to/rechunked/store.zarr
```

The logic for rechunking sits entirely within `dodola/services.py` because we're letting the `chunker` package do all the work and `chunker` is tightly coupled to the data model and storage details. We've been trying to keep the data model out of the `dodola/core.py`.

This refactors `dodola/repository.py` into a single class `_ZarrRepo` which users use/instantiate through functions `memory_repository()` and `adl_repository()` (formerly known as `FakeRepository` and `AzureZarr`). These instances behave like they did before (read xr.Datasets, write Zarr stores), but now they have a `get_mapper()` method so we can pass mappers into external packages like `rechunker` which requires them to stream output directly into a Zarr store.

Close #21