### PR TITLE
Add service for regridding zarrs

### DIFF
--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -126,7 +126,12 @@ def rechunk(x, variable, chunk, maxmemory, out):
     "--targetresolution", "-r", default=1.0, help="Global-grid resolution to regrid to"
 )
 @click.option("--out", "-o", required=True)
-@click.option("--weightspath", "-w", default=None, help="Local path to existing regrid weights file")
+@click.option(
+    "--weightspath",
+    "-w",
+    default=None,
+    help="Local path to existing regrid weights file",
+)
 def regrid(x, method, targetgrid, out, weightspath):
     """Regrid a target climate dataset
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -112,3 +112,34 @@ def rechunk(x, variable, chunk, maxmemory, out):
         max_mem=maxmemory,
         storage=_authenticate_storage(),
     )
+
+
+@dodola_cli.command(help="Build NetCDF weights file for regridding")
+@click.argument("x", required=True)
+@click.option(
+    "--method",
+    "-m",
+    required=True,
+    help="Regridding method - 'bilinear' or 'conservative'",
+)
+@click.option(
+    "--targetresolution", "-r", default=1.0, help="Global-grid resolution to regrid to"
+)
+@click.option("--out", "-o", required=True)
+@click.option("--weightspath", "-w", default=None, help="Local path to existing regrid weights file")
+def regrid(x, method, targetgrid, out, weightspath):
+    """Regrid a target climate dataset
+
+    Note, the weightspath only accepts paths to NetCDF files on the local disk. See
+    https://xesmf.readthedocs.io/ for details on requirements for `x` with
+    different methods.
+    """
+    # Configure storage while we have access to users configurations.
+    services.regrid(
+        str(x),
+        out=str(out),
+        method=str(method),
+        storage=_authenticate_storage(),
+        weights_path=weightspath,
+        target_resolution=float(targetgrid),
+    )

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -116,6 +116,7 @@ def rechunk(x, variable, chunk, maxmemory, out):
 
 @dodola_cli.command(help="Build NetCDF weights file for regridding")
 @click.argument("x", required=True)
+@click.option("--out", "-o", required=True)
 @click.option(
     "--method",
     "-m",
@@ -125,14 +126,13 @@ def rechunk(x, variable, chunk, maxmemory, out):
 @click.option(
     "--targetresolution", "-r", default=1.0, help="Global-grid resolution to regrid to"
 )
-@click.option("--out", "-o", required=True)
 @click.option(
     "--weightspath",
     "-w",
     default=None,
     help="Local path to existing regrid weights file",
 )
-def regrid(x, method, targetgrid, out, weightspath):
+def regrid(x, out, method, targetgrid, weightspath):
     """Regrid a target climate dataset
 
     Note, the weightspath only accepts paths to NetCDF files on the local disk. See

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -88,3 +88,29 @@ def build_xesmf_weights_file(x, method, target_resolution, filename=None):
         filename=filename,
     )
     return str(out.filename)
+
+
+def xesmf_regrid(x, method, target_resolution, weights_path=None):
+    """
+
+    Parameters
+    ----------
+    x : xr.Dataset
+    method : str
+        Method of regridding. Passed to ``xesmf.Regridder``.
+    target_resolution : float
+        Decimal-degree resolution of global latxlon grid to regrid to.
+    weights_path : str, optional
+        Local path to netCDF file of pre-calculated XESMF regridding weights.
+
+    Returns
+    -------
+    xr.Dataset
+    """
+    regridder = xe.Regridder(
+        x,
+        xe.util.grid_global(target_resolution, target_resolution),
+        method=method,
+        filename=weights_path,
+    )
+    return regridder(x)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -148,7 +148,10 @@ def regrid(x, out, method, storage, weights_path=None, target_resolution=1.0):
     """
     ds = storage.read(x)
     regridded_ds = xesmf_regrid(
-        ds, method=method, target_resolution=target_resolution, weights_path=weights_path
+        ds,
+        method=method,
+        target_resolution=target_resolution,
+        weights_path=weights_path,
     )
     storage.write(out, regridded_ds)
 

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -6,11 +6,11 @@ import dodola.services
 
 @pytest.mark.parametrize(
     "subcmd",
-    [None, "biascorrect", "buildweights", "rechunk"],
-    ids=("--help", "biascorrect --help", "buildweights --help", "rechunk --help"),
+    [None, "biascorrect", "buildweights", "rechunk", "regrid"],
+    ids=("--help", "biascorrect --help", "buildweights --help", "rechunk --help", "regrid --help"),
 )
 def test_cli_helpflags(subcmd):
-    """Test that CLI commands don't throw Error if given --help flag"""
+    """Test that CLI commands and subcommands don't throw Error if given --help flag"""
     runner = CliRunner()
 
     # Setup CLI args

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -7,7 +7,13 @@ import dodola.services
 @pytest.mark.parametrize(
     "subcmd",
     [None, "biascorrect", "buildweights", "rechunk", "regrid"],
-    ids=("--help", "biascorrect --help", "buildweights --help", "rechunk --help", "regrid --help"),
+    ids=(
+        "--help",
+        "biascorrect --help",
+        "buildweights --help",
+        "rechunk --help",
+        "regrid --help",
+    ),
 )
 def test_cli_helpflags(subcmd):
     """Test that CLI commands and subcommands don't throw Error if given --help flag"""

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -235,7 +235,7 @@ def test_regrid_resolution(target_resolution, expected_shape):
 
 def test_regrid_weights_integration(tmpdir):
     """Test basic integration between service.regrid and service.build_weights"""
-    expected_shape=(180, 360)
+    expected_shape = (180, 360)
     # Output to tmp dir so we cleanup & don't clobber existing files...
     weightsfile = tmpdir.join("a_file_path_weights.nc")
 
@@ -251,7 +251,10 @@ def test_regrid_weights_integration(tmpdir):
 
     # First, use service to pre-build regridding weights files, then read-in to regrid.
     build_weights(
-        "an/input/path.zarr", method="bilinear", storage=fakestorage, outpath=weightsfile
+        "an/input/path.zarr",
+        method="bilinear",
+        storage=fakestorage,
+        outpath=weightsfile,
     )
     regrid(
         "an/input/path.zarr",

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 from xesmf.data import wave_smooth
 from xesmf.util import grid_global
-from dodola.services import bias_correct, build_weights, rechunk
+from dodola.services import bias_correct, build_weights, rechunk, regrid
 from dodola.repository import memory_repository
 
 
@@ -150,3 +150,115 @@ def test_rechunk():
     actual_chunks = fakestorage.read("output_ds")["fakevariable"].data.chunksize
 
     assert actual_chunks == tuple(chunks_goal.values())
+
+
+@pytest.mark.parametrize(
+    "regrid_method, expected_shape",
+    [
+        pytest.param(
+            "bilinear",
+            (180, 360),
+            id="Bilinear regrid",
+        ),
+        pytest.param(
+            "conservative",
+            (180, 360),
+            id="Conservative regrid",
+        ),
+    ],
+)
+def test_regrid_methods(regrid_method, expected_shape):
+    """Smoke test that services.regrid outputs with different regrid methods
+
+    The the expected shape is the same, but change in methods should not error.
+    """
+    # Make fake input data.
+    ds_in = grid_global(30, 20)
+    ds_in["fakevariable"] = wave_smooth(ds_in["lon"], ds_in["lat"])
+
+    fakestorage = memory_repository(
+        {
+            "an/input/path.zarr": ds_in,
+        }
+    )
+
+    regrid(
+        "an/input/path.zarr",
+        out="an/output/path.zarr",
+        method=regrid_method,
+        storage=fakestorage,
+    )
+    actual_shape = fakestorage.read("an/output/path.zarr")["fakevariable"].shape
+    assert actual_shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    "target_resolution, expected_shape",
+    [
+        pytest.param(
+            1.0,
+            (180, 360),
+            id="Regrid to global 1.0° x 1.0° grid",
+        ),
+        pytest.param(
+            2.0,
+            (90, 180),
+            id="Regrid to global 2.0° x 2.0° grid",
+        ),
+    ],
+)
+def test_regrid_resolution(target_resolution, expected_shape):
+    """Smoke test that services.regrid outputs with different regrid methods
+
+    The the expected shape is the same, but change in methods should not error.
+    """
+    # Make fake input data.
+    ds_in = grid_global(30, 20)
+    ds_in["fakevariable"] = wave_smooth(ds_in["lon"], ds_in["lat"])
+
+    fakestorage = memory_repository(
+        {
+            "an/input/path.zarr": ds_in,
+        }
+    )
+
+    regrid(
+        "an/input/path.zarr",
+        out="an/output/path.zarr",
+        target_resolution=target_resolution,
+        method="bilinear",
+        storage=fakestorage,
+    )
+    actual_shape = fakestorage.read("an/output/path.zarr")["fakevariable"].shape
+    assert actual_shape == expected_shape
+
+
+def test_regrid_weights_integration(tmpdir):
+    """Test basic integration between service.regrid and service.build_weights"""
+    expected_shape=(180, 360)
+    # Output to tmp dir so we cleanup & don't clobber existing files...
+    weightsfile = tmpdir.join("a_file_path_weights.nc")
+
+    # Make fake input data.
+    ds_in = grid_global(30, 20)
+    ds_in["fakevariable"] = wave_smooth(ds_in["lon"], ds_in["lat"])
+
+    fakestorage = memory_repository(
+        {
+            "an/input/path.zarr": ds_in,
+        }
+    )
+
+    # First, use service to pre-build regridding weights files, then read-in to regrid.
+    build_weights(
+        "an/input/path.zarr", method="bilinear", storage=fakestorage, outpath=weightsfile
+    )
+    regrid(
+        "an/input/path.zarr",
+        out="an/output/path.zarr",
+        method="bilinear",
+        weights_path=weightsfile,
+        storage=fakestorage,
+    )
+    actual_shape = fakestorage.read("an/output/path.zarr")["fakevariable"].shape
+    assert actual_shape == expected_shape

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -170,7 +170,7 @@ def test_rechunk():
 def test_regrid_methods(regrid_method, expected_shape):
     """Smoke test that services.regrid outputs with different regrid methods
 
-    The the expected shape is the same, but change in methods should not error.
+    The expected shape is the same, but change in methods should not error.
     """
     # Make fake input data.
     ds_in = grid_global(30, 20)
@@ -210,7 +210,7 @@ def test_regrid_methods(regrid_method, expected_shape):
 def test_regrid_resolution(target_resolution, expected_shape):
     """Smoke test that services.regrid outputs with different regrid methods
 
-    The the expected shape is the same, but change in methods should not error.
+    The expected shape is the same, but change in methods should not error.
     """
     # Make fake input data.
     ds_in = grid_global(30, 20)


### PR DESCRIPTION
Adds service to regrid zarr files with `xesmf`.

Basic interface from CLI is 
```bash
dodola regrid /path/to/store.zarr \
    --out /path/to/regrid.zarr \
    --method "bilinear"
```
Can use `-r`/`--targetresolution` to set the target global grid resolution (1.0 x 1.0 is default). Can use `-w`/`--weightspath` to use to any precalculated regridding weights in a NetCDF file on disk.

Includes integration test to ensure regridding works with pre-computed regridding weights from `dodola buildweights`.

Close #27.