### PR TITLE
Fix exception catching in logging decorator

### DIFF
--- a/dodola/services.py
+++ b/dodola/services.py
@@ -12,12 +12,14 @@ logger = logging.getLogger(__name__)
 
 def log_service(func):
     """Decorator for dodola.services to log service start and stop"""
+
     @wraps(func)
     def service_logger(*args, **kwargs):
         servicename = func.__name__
         logger.info(f"Starting {servicename} dodola service")
         func(*args, **kwargs)
         logger.info(f"dodola service {servicename} done")
+
     return service_logger
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -11,17 +11,13 @@ logger = logging.getLogger(__name__)
 
 
 def log_service(func):
+    """Decorator for dodola.services to log service start and stop"""
     @wraps(func)
     def service_logger(*args, **kwargs):
         servicename = func.__name__
-        try:
-            logger.info(f"Starting {servicename} dodola service")
-            func(*args, **kwargs)
-        except Exception:
-            logger.exception(f"Fatal error in {servicename} dodola service")
-        else:
-            logger.info(f"dodola service {servicename} done")
-
+        logger.info(f"Starting {servicename} dodola service")
+        func(*args, **kwargs)
+        logger.info(f"dodola service {servicename} done")
     return service_logger
 
 


### PR DESCRIPTION
Fixes a bug that made debugging from tests and CI/CD very difficult.

This should be high priority to merge. This is also my bad. The solution keeps things very simple.

Close #30