### PR TITLE
Cast CLI option to int, fix rechunker maxmem error

### DIFF
--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -109,7 +109,10 @@ def buildweights(x, method, targetresolution, outpath):
     "--chunk", "-c", multiple=True, required=True, help="coord=chunksize to rechunk to"
 )
 @click.option(
-    "--maxmemory", "-m", required=True, help="Max memory (bytes) to use for rechunking"
+    "--maxmemory",
+    "-m", type=int,
+    required=True,
+    help="Max memory (bytes) to use for rechunking"
 )
 @click.option("--out", "-o", required=True)
 def rechunk(x, variable, chunk, maxmemory, out):

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -113,7 +113,7 @@ def buildweights(x, method, targetresolution, outpath):
     "-m",
     type=int,
     required=True,
-    help="Max memory (bytes) to use for rechunking"
+    help="Max memory (bytes) to use for rechunking",
 )
 @click.option("--out", "-o", required=True)
 def rechunk(x, variable, chunk, maxmemory, out):

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -110,7 +110,8 @@ def buildweights(x, method, targetresolution, outpath):
 )
 @click.option(
     "--maxmemory",
-    "-m", type=int,
+    "-m",
+    type=int,
     required=True,
     help="Max memory (bytes) to use for rechunking"
 )


### PR DESCRIPTION
Our CLI help for `dodola rechunk` says we should be passing in `maxmem` as bytes. This PR ensures this is cast as `int` and not a `str`, which `rechunker` doesn't seem to like.

This PR does not change the `dodola rechunk` CLI. Pure bug fix.

close #48
