### PR TITLE
Fix bad ffspec, adlfs imports

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
 - adlfs=0.6
 - click
 - cftime
-- fsspec=0.8.7 # Pinned req. for adlfs > 0.7
+- fsspec=0.8.7 # Pinned req. for adlfs < 0.7
 - numpy
 - pip
 - pytest

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
 - adlfs=0.6
 - click
 - cftime
-- fsspec
+- fsspec=0.8.7 # Pinned req. for adlfs > 0.7
 - numpy
 - pip
 - pytest


### PR DESCRIPTION
This is complicated but, `adlfs` <= 0.7 requires `fsspec` <= 0.9. Otherwise it tries to import things that arn't there and breaks our CI/CD. See the closed issue for more details.

close #53