### PR TITLE
Use simple xarray rechunking

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* 
+* Switch to simple ``xarray``-based rechunking to workaround to instability from our use of ``rechunker``. This change breaks the CLI for ``dodola rechunk``, removing the ``-v/--variable`` and ``-m/--maxmemory`` options. The change also breaks the ``dodola.services.rechunk()`` signature, removing the ``max_mem`` argument and the ``target_chunks`` argument is now a mapping ``{coordinate_name: chunk_size}``.
 
 
 0.1.0 (2021-04-15)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Switch to simple ``xarray``-based rechunking to workaround to instability from our use of ``rechunker``. This change breaks the CLI for ``dodola rechunk``, removing the ``-v/--variable`` and ``-m/--maxmemory`` options. The change also breaks the ``dodola.services.rechunk()`` signature, removing the ``max_mem`` argument and the ``target_chunks`` argument is now a mapping ``{coordinate_name: chunk_size}``.
+* Switch to simple ``xarray``-based rechunking to workaround to instability from our use of ``rechunker``. This change breaks the CLI for ``dodola rechunk``, removing the ``-v/--variable`` and ``-m/--maxmemory`` options. The change also breaks the ``dodola.services.rechunk()`` signature, removing the ``max_mem`` argument and the ``target_chunks`` argument is now a mapping ``{coordinate_name: chunk_size}``. (PR#60, @brews)
 
 
 0.1.0 (2021-04-15)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -125,16 +125,8 @@ def buildweights(x, method, targetresolution, outpath):
 
 @dodola_cli.command(help="Rechunk Zarr store")
 @click.argument("x", required=True)
-@click.option("--variable", "-v", required=True, help="Variable to rechunk")
 @click.option(
     "--chunk", "-c", multiple=True, required=True, help="coord=chunksize to rechunk to"
-)
-@click.option(
-    "--maxmemory",
-    "-m",
-    type=int,
-    required=True,
-    help="Max memory (bytes) to use for rechunking",
 )
 @click.option("--out", "-o", required=True)
 def rechunk(x, variable, chunk, maxmemory, out):
@@ -147,7 +139,6 @@ def rechunk(x, variable, chunk, maxmemory, out):
         str(x),
         target_chunks=target_chunks,
         out=out,
-        max_mem=maxmemory,
         storage=_authenticate_storage(),
     )
 

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -48,7 +48,7 @@ class _ZarrRepo:
         -------
         xr.Dataset
         """
-        x = open_zarr(self.get_mapper(url_or_path))
+        x = open_zarr(self._fs.get_mapper(url_or_path))
         logger.info(f"Read {url_or_path}")
         return x
 
@@ -64,24 +64,8 @@ class _ZarrRepo:
             Location to write Zarr store to.
         x : xr.Dataset
         """
-        x.to_zarr(self.get_mapper(url_or_path), mode="w", compute=True)
+        x.to_zarr(self._fs.get_mapper(url_or_path), mode="w", compute=True)
         logger.info(f"Written {url_or_path}")
-
-    def get_mapper(self, root, check=False, create=False):
-        """Get fsspec.FSMap from wrapped FileSystemAbstraction
-
-        Parameters
-        ----------
-        root : str
-        check : bool
-            Do touch at storage to check for write access.
-        create : bool
-
-        Returns
-        -------
-        out : fsspec.FSMap
-        """
-        return self._fs.get_mapper(root, check=check, create=create)
 
 
 def adl_repository(

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -2,9 +2,6 @@
 """
 from functools import wraps
 import logging
-import os
-from tempfile import TemporaryDirectory
-from rechunker import rechunk as rechunker_rechunk
 from dodola.core import (
     apply_bias_correction,
     build_xesmf_weights_file,
@@ -97,7 +94,7 @@ def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
 
 
 @log_service
-def rechunk(x, target_chunks, out, max_mem, storage):
+def rechunk(x, target_chunks, out, storage):
     """Rechunk data to specification
 
     Parameters
@@ -105,30 +102,25 @@ def rechunk(x, target_chunks, out, max_mem, storage):
     x : str
         Storage URL to input data.
     target_chunks : dict
-        A dict of dicts. Top-level dict key maps variables name in `ds` to an
-        inner dict {coordinate_name: chunk_size} mapping showing how data is
+        Mapping {coordinate_name: chunk_size} showing how data is
         to be rechunked.
     out : str
         Storage URL to write rechunked output to.
-    max_mem : int or str
-        Maximum memory to use for rechunking (bytes).
     storage : dodola.repository._ZarrRepo
         Storage abstraction for data IO.
     """
     ds = storage.read(x)
 
-    # Using tempdir for isolation/cleanup as rechunker dumps zarr files to disk.
-    with TemporaryDirectory() as tmpdir:
-        tmpzarr_path = os.path.join(tmpdir, "rechunk_tmp.zarr")
-        plan = rechunker_rechunk(
-            ds,
-            target_chunks=target_chunks,
-            target_store=storage.get_mapper(out),  # Stream directly into storage.
-            temp_store=tmpzarr_path,
-            max_mem=max_mem,
-        )
-        plan.execute()
-        logger.info(f"Written {out}")
+    # Simple, stable, but not for more specialized rechunking needs.
+    # In that case use "rechunker" package, or similar.
+    ds = ds.chunk(target_chunks)
+
+    # Hack to get around issue with writing chunks to zarr in xarray ~v0.17.0
+    # https://github.com/pydata/xarray/issues/2300
+    for v in ds.data_vars.keys():
+        del ds[v].encoding["chunks"]
+
+    storage.write(out, ds)
 
 
 @log_service

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -205,9 +205,8 @@ def test_rechunk():
 
     rechunk(
         "input_ds",
-        target_chunks={"fakevariable": chunks_goal},
+        target_chunks=chunks_goal,
         out="output_ds",
-        max_mem=256000,
         storage=fakestorage,
     )
     actual_chunks = fakestorage.read("output_ds")["fakevariable"].data.chunksize

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -6,7 +6,6 @@ import pytest
 import xarray as xr
 from xesmf.data import wave_smooth
 from xesmf.util import grid_global
-from xclim.core.calendar import convert_calendar
 from dodola.services import (
     bias_correct,
     build_weights,

--- a/environment.yaml
+++ b/environment.yaml
@@ -10,7 +10,6 @@ dependencies:
 - pip
 - pytest
 - python=3.8
-- rechunker
 - xarray
 - xesmf
 - esmpy=8.0.1=nompi_py38h5410a82_2  # Not direct dep. Dep of xesmf.

--- a/environment.yaml
+++ b/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
 - pip
 - pytest
 - python=3.8
-- xarray
+- xarray=0.17.0 # Pinned for bug in dodola.services.rechunk
 - xesmf
 - esmpy=8.0.1=nompi_py38h5410a82_2  # Not direct dep. Dep of xesmf.
 - bottleneck


### PR DESCRIPTION
Swaps our `rechunker`-based rechunking for more memory-intensive (but stable) `xarray`-based rechunking.

This PR makes breaking changes to `dodola rechunk`, dropping the `variable` and `maxmemory` options. Similar breaking changes in `dodola.services.rechunk()`, notably `target_chunks` is now just a mapping of coordinate to their rechunk size.

Internally, also dropped the `get_mapper()` method from `dodola.respository` because it's not needed. `rechunker` support was the only need.

Close #57 
