### PR TITLE
Require fsspec URLs, refactor

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* 
+* Switch to pure ``fsspec``-style URLs for data inputs. Added support for GCS buckets and S3 storage. Switch to ``fsspec`` backend settings to collect storage authentication. Because of this users likely will need to change the environment variables used to pass in storage credentials. ``dodola.services`` no longer require the ``storage`` argument. (PR#61, @brews)
 
 
 0.1.0 (2021-04-15)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -1,25 +1,12 @@
 """Commandline interface to the application.
 """
 
-from os import getenv
 import logging
 import click
 import dodola.services as services
-from dodola.repository import adl_repository
 
 
 logger = logging.getLogger(__name__)
-
-
-def _authenticate_storage():
-    storage = adl_repository(
-        account_name=getenv("AZURE_STORAGE_ACCOUNT"),
-        account_key=getenv("AZURE_STORAGE_KEY"),
-        client_id=getenv("AZURE_CLIENT_ID"),
-        client_secret=getenv("AZURE_CLIENT_SECRET"),
-        tenant_id=getenv("AZURE_TENANT_ID"),
-    )
-    return storage
 
 
 # Main entry point
@@ -28,10 +15,8 @@ def _authenticate_storage():
 def dodola_cli(debug):
     """GCM bias-correction and downscaling
 
-    Authenticate with storage by setting the AZURE_STORAGE_ACCOUNT and
-    AZURE_STORAGE_KEY environment variables for key-based authentication.
-    Alternatively, set AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and
-    AZURE_TENANT_ID for service principal-based authentication.
+    Authenticate with storage by setting the appropriate environment variables
+    for your fsspec-compatibile URL library.
     """
     noisy_loggers = [
         "azure.core.pipeline.policies.http_logging_policy",
@@ -61,7 +46,7 @@ def dodola_cli(debug):
 )
 def cleancmip6(x, out, drop_leapdays):
     """Clean and standardize CMIP6 GCM to 'out'. If drop-leapdays option is set, remove leap days"""
-    services.clean_cmip6(x, out, drop_leapdays, storage=_authenticate_storage())
+    services.clean_cmip6(x, out, drop_leapdays)
 
 
 @dodola_cli.command(help="Remove leap days and update calendar")
@@ -69,7 +54,7 @@ def cleancmip6(x, out, drop_leapdays):
 @click.argument("out", required=True)
 def removeleapdays(x, out):
     """ Remove leap days and update calendar attribute"""
-    services.remove_leapdays(x, out, storage=_authenticate_storage())
+    services.remove_leapdays(x, out)
 
 
 @dodola_cli.command(help="Bias-correct GCM on observations")
@@ -87,7 +72,6 @@ def biascorrect(x, xtrain, trainvariable, ytrain, out, outvariable, method):
         xtrain,
         ytrain,
         out,
-        storage=_authenticate_storage(),
         train_variable=trainvariable,
         out_variable=outvariable,
         method=method,
@@ -118,7 +102,6 @@ def buildweights(x, method, targetresolution, outpath):
         str(x),
         str(method),
         target_resolution=float(targetresolution),
-        storage=_authenticate_storage(),
         outpath=str(outpath),
     )
 
@@ -148,7 +131,6 @@ def rechunk(x, variable, chunk, maxmemory, out):
         target_chunks=target_chunks,
         out=out,
         max_mem=maxmemory,
-        storage=_authenticate_storage(),
     )
 
 
@@ -180,7 +162,6 @@ def regrid(x, out, method, domain_file, weightspath):
         str(x),
         out=str(out),
         method=str(method),
-        storage=_authenticate_storage(),
         domain_file=domain_file,
         weights_path=weightspath,
     )

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -16,7 +16,7 @@ def dodola_cli(debug):
     """GCM bias-correction and downscaling
 
     Authenticate with storage by setting the appropriate environment variables
-    for your fsspec-compatibile URL library.
+    for your fsspec-compatible URL library.
     """
     noisy_loggers = [
         "azure.core.pipeline.policies.http_logging_policy",

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -28,7 +28,7 @@ def read(url_or_path):
 def write(url_or_path, x):
     """Write Dataset to Zarr store
 
-    This opens Zarr store with mode "w" and is called with with
+    This opens Zarr store with mode "w" and is called with
     ``compute=True``, so any lazy computations will be completed.
 
     Parameters

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -2,142 +2,58 @@
 """
 
 import logging
-from adlfs import AzureBlobFileSystem
-from fsspec.implementations.memory import MemoryFileSystem
+from fsspec import get_mapper as fs_get_mapper
 from xarray import open_zarr
 
 
 logger = logging.getLogger(__name__)
 
 
-class _ZarrRepo:
-    """Puts a simple read-Dataset/write-Zarr interface over fsspec-like storage
-
-    This puts a basic read/write repository pattern over a file
-    system to abstract-away the data layer. Aside from the ``read()``
-    and ``write()`` methods, the additional ``get_mapper()`` method is for
-    external packages that couple directly with `fsspec` to stream output
-    immediately into storage.
-
-    This is commonly instantiated through ``adl_repository``, or for testing
-    with ``memory_repository``.
+def read(url_or_path):
+    """Read Dataset from Zarr store
 
     Parameters
     ----------
-    fs : fsspec.AbstractFileSystem-like
-
-    See Also
-    --------
-    adl_repository: Instantiate a Zarr data repo using Azure Datalake Gen. 2 as backend
-    memory_repository: Instantiate a Zarr data repo in memory
-
-    """
-
-    def __init__(self, fs):
-        self._fs = fs
-
-    def read(self, url_or_path):
-        """Read Dataset from Zarr store
-
-        Parameters
-        ----------
-        url_or_path : str
-            Location of Zarr store to read.
-
-        Returns
-        -------
-        xr.Dataset
-        """
-        x = open_zarr(self.get_mapper(url_or_path))
-        logger.info(f"Read {url_or_path}")
-        return x
-
-    def write(self, url_or_path, x):
-        """Write Dataset to Zarr store
-
-        This opens Zarr store with mode "w" and is called with with
-        ``compute=True``, so any lazy computations will be completed.
-
-        Parameters
-        ----------
-        url_or_path : str
-            Location to write Zarr store to.
-        x : xr.Dataset
-        """
-        x.to_zarr(self.get_mapper(url_or_path), mode="w", compute=True)
-        logger.info(f"Written {url_or_path}")
-
-    def get_mapper(self, root, check=False, create=False):
-        """Get fsspec.FSMap from wrapped FileSystemAbstraction
-
-        Parameters
-        ----------
-        root : str
-        check : bool
-            Do touch at storage to check for write access.
-        create : bool
-
-        Returns
-        -------
-        out : fsspec.FSMap
-        """
-        return self._fs.get_mapper(root, check=check, create=create)
-
-
-def adl_repository(
-    account_name=None,
-    account_key=None,
-    client_id=None,
-    client_secret=None,
-    tenant_id=None,
-):
-    """Instantiate a Zarr data repo using Azure Datalake Gen. 2 as backend
-
-    To authenticate with storage must pass in `account_name` and
-    `account_key` for key-based authentication or `client_id`, `client_secret`,
-    and `tenant_id` for authentication with service principal
-    credentials. Initializing arguments are passed to ``adlfs.AzureBlobFileSystem``.
-
-    Parameters
-    ----------
-    account_name : str or None, optional
-    account_key : str or None, optional
-    client_id : str or None, optional
-    client_secret : str or None, optional
-    tenant_id : str or None, optional
+    url_or_path : str
+        Location of Zarr store to read.
 
     Returns
     -------
-    repo : dodola.repository._ZarrRepo
+    xr.Dataset
     """
-    repo = _ZarrRepo(
-        fs=AzureBlobFileSystem(
-            account_name=account_name,
-            account_key=account_key,
-            client_id=client_id,
-            client_secret=client_secret,
-            tenant_id=tenant_id,
-        )
-    )
-    return repo
+    x = open_zarr(url_or_path)
+    logger.info(f"Read {url_or_path}")
+    return x
 
 
-def memory_repository(storage=None):
-    """Instantiate a Zarr data repo in memory
+def write(url_or_path, x):
+    """Write Dataset to Zarr store
 
-    This is most commonly used for testing. Keep in mind that all instances
-    share memory globally.
+    This opens Zarr store with mode "w" and is called with with
+    ``compute=True``, so any lazy computations will be completed.
 
     Parameters
     ----------
-    storage : dict or None, optional
-        Mapping of `{path: data}` to immediately store into memory filesystem.
+    url_or_path : str
+        Location to write Zarr store to.
+    x : xr.Dataset
+    """
+    x.to_zarr(url_or_path, mode="w", compute=True)
+    logger.info(f"Written {url_or_path}")
+
+
+def get_mapper(root, check=False, create=False):
+    """Get fsspec.FSMap from wrapped FileSystemAbstraction
+
+    Parameters
+    ----------
+    root : str
+    check : bool
+        Do touch at storage to check for write access.
+    create : bool
 
     Returns
     -------
-    repo : dodola.repository._ZarrRepo
+    out : fsspec.FSMap
     """
-    repo = _ZarrRepo(fs=MemoryFileSystem())
-    for k, v in storage.items():
-        repo.write(k, v)
-    return repo
+    return fs_get_mapper(root, check=check, create=create)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -12,6 +12,7 @@ from dodola.core import (
     standardize_gcm,
     xclim_remove_leapdays,
 )
+import dodola.repository as storage
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +31,7 @@ def log_service(func):
 
 
 @log_service
-def bias_correct(
-    x, x_train, train_variable, y_train, out, out_variable, method, storage
-):
+def bias_correct(x, x_train, train_variable, y_train, out, out_variable, method):
     """Bias correct input model data with IO to storage
 
     Parameters
@@ -53,8 +52,6 @@ def bias_correct(
         Variable name used as output variable name.
     method : str
         Bias correction method to be used.
-    storage : dodola.repository._ZarrRepo
-        Storage abstraction for data IO.
     """
     gcm_training_ds = storage.read(x_train)
     obs_training_ds = storage.read(y_train)
@@ -74,7 +71,7 @@ def bias_correct(
 
 
 @log_service
-def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
+def build_weights(x, method, target_resolution=1.0, outpath=None):
     """Generate local NetCDF weights file for regridding climate data
 
     Parameters
@@ -85,8 +82,6 @@ def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
         Method of regridding. Passed to ``xesmf.Regridder``.
     target_resolution : float, optional
         Decimal-degree resolution of global grid to regrid to.
-    storage : dodola.repository._ZarrRepo
-        Storage abstraction for data IO.
     outpath : optional
         Local file path name to write regridding weights file to.
     """
@@ -97,7 +92,7 @@ def build_weights(x, method, storage, target_resolution=1.0, outpath=None):
 
 
 @log_service
-def rechunk(x, target_chunks, out, max_mem, storage):
+def rechunk(x, target_chunks, out, max_mem):
     """Rechunk data to specification
 
     Parameters
@@ -112,8 +107,6 @@ def rechunk(x, target_chunks, out, max_mem, storage):
         Storage URL to write rechunked output to.
     max_mem : int or str
         Maximum memory to use for rechunking (bytes).
-    storage : dodola.repository._ZarrRepo
-        Storage abstraction for data IO.
     """
     ds = storage.read(x)
 
@@ -132,7 +125,7 @@ def rechunk(x, target_chunks, out, max_mem, storage):
 
 
 @log_service
-def regrid(x, out, method, storage, domain_file, weights_path=None):
+def regrid(x, out, method, domain_file, weights_path=None):
     """Regrid climate data
 
     Parameters
@@ -143,8 +136,6 @@ def regrid(x, out, method, storage, domain_file, weights_path=None):
         Storage URL to write regridded output to.
     method : str
         Method of regridding. Passed to ``xesmf.Regridder``.
-    storage : dodola.repository._ZarrRepo
-        Storage abstraction for data IO.
     domain_file : str
         Storage URL to input xr.Dataset domain file to regrid to.
     weights_path : optional
@@ -165,7 +156,7 @@ def regrid(x, out, method, storage, domain_file, weights_path=None):
 
 
 @log_service
-def clean_cmip6(x, out, leapday_removal, storage):
+def clean_cmip6(x, out, leapday_removal):
     """Cleans and standardizes CMIP6 GCM
 
     Parameters
@@ -176,8 +167,6 @@ def clean_cmip6(x, out, leapday_removal, storage):
         Storage URL to write cleaned GCM output to.
     leapday_removal : bool
         Whether or not to remove leap days.
-    storage : dodola.repository._ZarrRepo
-        Storage abstraction for data IO.
     """
     ds = storage.read(x)
     cleaned_ds = standardize_gcm(ds, leapday_removal)
@@ -185,7 +174,7 @@ def clean_cmip6(x, out, leapday_removal, storage):
 
 
 @log_service
-def remove_leapdays(x, out, storage):
+def remove_leapdays(x, out):
     """Removes leap days and updates calendar attribute
 
     Parameters
@@ -194,8 +183,6 @@ def remove_leapdays(x, out, storage):
         Storage URL to input xr.Dataset that will be regridded.
     out : str
         Storage URL to write regridded output to.
-    storage : dodola.repository._ZarrRepo
-        Storage abstraction for data IO.
     """
     ds = storage.read(x)
     noleap_ds = xclim_remove_leapdays(ds)

--- a/dodola/tests/test_repository.py
+++ b/dodola/tests/test_repository.py
@@ -1,15 +1,16 @@
-from xarray import Dataset
-from dodola.repository import memory_repository
+from xarray import Dataset, open_zarr
+import dodola.repository
 
 
 def test_memory_repository_read():
     """Basic test that memory_repository.read() works"""
-    storage = memory_repository(storage={"foo": Dataset({"bar": 123})})
-    assert storage.read(url_or_path="foo") == Dataset({"bar": 123})
+    url = "memory://test_memory_repository_read.zarr"
+    Dataset({"bar": 321}).to_zarr(url)  # Manually write to memory FS.
+    assert dodola.repository.read(url) == Dataset({"bar": 123})
 
 
 def test_memory_repository_write():
     """Basic test that memory_repository.write() works"""
-    storage = memory_repository(storage={"foo": Dataset({"bar": 321})})
-    storage.write(url_or_path="foo", x=Dataset({"bar": "SPAM"}))
-    assert storage.read(url_or_path="foo") == Dataset({"bar": "SPAM"})
+    url = "memory://test_memory_repository_write.zarr"
+    dodola.repository.write(url, Dataset({"bar": "SPAM"}))
+    assert open_zarr(url) == Dataset({"bar": "SPAM"})

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,11 +6,13 @@ dependencies:
 - click
 - cftime
 - fsspec=0.8.7 # Pinned req. for adlfs < 0.7
+- gcsfs
 - numpy
 - pip
 - pytest
 - python=3.8
 - rechunker
+- s3fs
 - xarray
 - xesmf
 - esmpy=8.0.1=nompi_py38h5410a82_2  # Not direct dep. Dep of xesmf.


### PR DESCRIPTION
With this PR just about all data inputs need to be `fsspec` URLs. All storage authentication gets passed through fsspec-storage backend default environment variables. `dodola.services` functions no longer require the `storage` arg. 

In short, we spec storage with URLs like:
```
dodola cleancmip6 az://raw/gfdl.zarr az://clean/gfdl.zarr
```

Storage is authenticated completely through input `fsspec` URLs on a data-by-data basis. This means functions requiring multiple input data can read the data from different `fsspec` backends.

In terms of package architecture, storage I/O (`dodola/repository.py`) would now happen in `dodola/services.py`. `dodola/core.py` and notably `dodola/cli.py`. Both are now decoupled from storage logic.

`dodola` will accept URLs for S3 (via `s3fs`) and GCS buckets (via `gcsfs`), among others. See `fsspec` registry for list of supported protocols and the corresponding required packages. https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/registry.html

Because we're mostly using Azure storage on the backend for this project, users won't be able to pass in credentials with the old `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY`, for example. Under this PR, users need the `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY` because these are the environment variables used by the `fsspec` backend for Azure Gen 2 Datalake, `adlfs`. This is another breaking change.

There was some light refactoring to accommodate all this.

 Close #56, close #55