### PR TITLE
Fix TypeError in dodola.cli.py::rechunk

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
+* Fix ``TypeError`` from `dodola rechunk`. (PR#63, @brews)
 * Switch to pure ``fsspec``-style URLs for data inputs. Added support for GCS buckets and S3 storage. Switch to ``fsspec`` backend settings to collect storage authentication. Because of this users likely will need to change the environment variables used to pass in storage credentials. ``dodola.services`` no longer require the ``storage`` argument. (PR#61, @brews)
 * Switch to simple ``xarray``-based rechunking to workaround to instability from our use of ``rechunker``. This change breaks the CLI for ``dodola rechunk``, removing the ``-v/--variable`` and ``-m/--maxmemory`` options. The change also breaks the ``dodola.services.rechunk()`` signature, removing the ``max_mem`` argument and the ``target_chunks`` argument is now a mapping ``{coordinate_name: chunk_size}``. (PR#60, @brews)
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -116,11 +116,10 @@ def rechunk(x, chunk, out):
     """Rechunk Zarr store"""
     # Convert ["k1=1", "k2=2"] into {k1: 1, k2: 2}
     coord_chunks = {c.split("=")[0]: int(c.split("=")[1]) for c in chunk}
-    target_chunks = {variable: coord_chunks}
 
     services.rechunk(
         str(x),
-        target_chunks=target_chunks,
+        target_chunks=coord_chunks,
         out=out,
     )
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -112,7 +112,7 @@ def buildweights(x, method, targetresolution, outpath):
     "--chunk", "-c", multiple=True, required=True, help="coord=chunksize to rechunk to"
 )
 @click.option("--out", "-o", required=True)
-def rechunk(x, variable, chunk, maxmemory, out):
+def rechunk(x, chunk, out):
     """Rechunk Zarr store"""
     # Convert ["k1=1", "k2=2"] into {k1: 1, k2: 2}
     coord_chunks = {c.split("=")[0]: int(c.split("=")[1]) for c in chunk}


### PR DESCRIPTION
Get this when running the new `dodola rechunk`:

```
dc6-dev-djdj6-3755863106: Traceback (most recent call last):
dc6-dev-djdj6-3755863106:   File "/opt/conda/bin/dodola", line 33, in <module>
dc6-dev-djdj6-3755863106:     sys.exit(load_entry_point('dodola', 'console_scripts', 'dodola')())
dc6-dev-djdj6-3755863106:   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 829, in __call__
dc6-dev-djdj6-3755863106:     return self.main(*args, **kwargs)
dc6-dev-djdj6-3755863106:   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 782, in main
dc6-dev-djdj6-3755863106:     rv = self.invoke(ctx)
dc6-dev-djdj6-3755863106:   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
dc6-dev-djdj6-3755863106:     return _process_result(sub_ctx.command.invoke(sub_ctx))
dc6-dev-djdj6-3755863106:   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
dc6-dev-djdj6-3755863106:     return ctx.invoke(self.callback, **ctx.params)
dc6-dev-djdj6-3755863106:   File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 610, in invoke
dc6-dev-djdj6-3755863106:     return callback(*args, **kwargs)
dc6-dev-djdj6-3755863106: TypeError: rechunk() missing 2 required positional arguments: 'variable' and 'maxmemory'
```

In PR #60, looks like we failed to properly connect/reconnect the CLI inputs and `dodola.services.rechunk` (again). Should consider testing for this if this becomes more and more common.