### PR TITLE
Add downscaling service

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 0.X.X (XXXX-XX-XX)
 ------------------
 * Update buildweights service to add support for regridding to domain file. Not backwards compatible. (PR#67, @dgergel)
-
+* Add downscaling service. Currently support BCSD spatial disaggregation as implemented in scikit-downscale. (PR#65, @dgergel)
 
 0.2.0 (2021-04-23)
 ------------------

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -53,7 +53,7 @@ def cleancmip6(x, out, drop_leapdays):
 @click.argument("x", required=True)
 @click.argument("out", required=True)
 def removeleapdays(x, out):
-    """ Remove leap days and update calendar attribute"""
+    """Remove leap days and update calendar attribute"""
     services.remove_leapdays(x, out)
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -80,14 +80,20 @@ def biascorrect(x, xtrain, trainvariable, ytrain, out, outvariable, method):
 
 @dodola_cli.command(help="Downscale bias-corrected GCM")
 @click.argument("x", required=True)
-@click.argument("trainvariable", required=True)
-@click.argument("yclimocoarse", required=True)
-@click.argument("yclimofine", required=True)
-@click.argument("out", required=True)
-@click.argument("af", required=False)
-@click.argument("outvariable", required=True)
-@click.argument("method", required=True)
+@click.option("--trainvariable", "-tv", required=True)
+@click.option(
+    "--yclimocoarse", "-ycc", required=True, help="Coarse resolution obs climatology"
+)
+@click.option(
+    "--yclimofine", "-ycf", required=True, help="Fine resolution obs climatology"
+)
+@click.option("--out", "-o", required=True)
+@click.option("--outvariable", "-ov", required=True)
+@click.argument("--method", "-m", required=True, help="Downscaling method")
 @click.option("--domain-file", "-d", required=True, help="Domain file to regrid to")
+@click.option(
+    "--adjustmentfactors", "-af", default=None, help="Outpath for adjustment factors"
+)
 @click.option(
     "--weightspath",
     "-w",
@@ -100,23 +106,23 @@ def downscale(
     yclimocoarse,
     yclimofine,
     out,
-    af,
     outvariable,
     method,
     domain_file,
+    adjustmentfactors,
     weightspath,
 ):
     """Downscale bias corrected GCM to 'out' based on obs climo (yclimocoarse, yclimofine) using (method) and (domain_file)"""
     services.downscale(
         x,
-        yclimocoarse,
-        yclimofine,
-        out,
-        af,
+        yclimocoarse=yclimocoarse,
+        yclimofine=yclimofine,
+        out=out,
         train_variable=trainvariable,
         out_variable=outvariable,
         method=method,
         domain_file=domain_file,
+        adjustmentfactors=adjustmentfactors,
         weights_path=weightspath,
     )
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -97,25 +97,46 @@ def biascorrect(x, xtrain, trainvariable, ytrain, out, outvariable, method):
 @dodola_cli.command(help="Downscale bias-corrected GCM")
 @click.argument("x", required=True)
 @click.argument("trainvariable", required=True)
-@click.argument("ytrain", required=True)
-@click.argument("yclimo", required=True)
+@click.argument("yclimocoarse", required=True)
+@click.argument("yclimofine", required=True)
 @click.argument("out", required=True)
 @click.argument("af", required=False)
 @click.argument("outvariable", required=True)
 @click.argument("method", required=True)
-def downscale(x, trainvariable, ytrain, yclimo, out, af, outvariable, method):
-   """Downscale bias corrected GCM to 'out' based on obs (ytrain) and obs climo (yclimo) using (method)"""
-   services.downscale(
-       x, 
-       ytrain, 
-       yclimo, 
-       out,
-       af, 
-       storage=_authenticate_storage(),
-       train_variable=trainvariable,
-       out_variable=outvariable,
-       method=method,
-   )
+@click.option("--domain-file", "-d", required=True, help="Domain file to regrid to")
+@click.option(
+    "--weightspath",
+    "-w",
+    default=None,
+    help="Local path to existing regrid weights file",
+)
+def downscale(
+    x,
+    trainvariable,
+    yclimocoarse,
+    yclimofine,
+    out,
+    af,
+    outvariable,
+    method,
+    domain_file,
+    weightspath,
+):
+    """Downscale bias corrected GCM to 'out' based on obs climo (yclimocoarse, yclimofine) using (method) and (domain_file)"""
+    services.downscale(
+        x,
+        yclimocoarse,
+        yclimofine,
+        out,
+        af,
+        storage=_authenticate_storage(),
+        train_variable=trainvariable,
+        out_variable=outvariable,
+        method=method,
+        domain_file=domain_file,
+        weights_path=weights_path,
+    )
+
 
 @dodola_cli.command(help="Build NetCDF weights file for regridding")
 @click.argument("x", required=True)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -94,6 +94,29 @@ def biascorrect(x, xtrain, trainvariable, ytrain, out, outvariable, method):
     )
 
 
+@dodola_cli.command(help="Downscale bias-corrected GCM")
+@click.argument("x", required=True)
+@click.argument("trainvariable", required=True)
+@click.argument("ytrain", required=True)
+@click.argument("yclimo", required=True)
+@click.argument("out", required=True)
+@click.argument("af", required=False)
+@click.argument("outvariable", required=True)
+@click.argument("method", required=True)
+def downscale(x, trainvariable, ytrain, yclimo, out, af, outvariable, method):
+   """Downscale bias corrected GCM to 'out' based on obs (ytrain) and obs climo (yclimo) using (method)"""
+   services.downscale(
+       x, 
+       ytrain, 
+       yclimo, 
+       out,
+       af, 
+       storage=_authenticate_storage(),
+       train_variable=trainvariable,
+       out_variable=outvariable,
+       method=method,
+   )
+
 @dodola_cli.command(help="Build NetCDF weights file for regridding")
 @click.argument("x", required=True)
 @click.option(

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -134,7 +134,7 @@ def downscale(
         out_variable=outvariable,
         method=method,
         domain_file=domain_file,
-        weights_path=weights_path,
+        weights_path=weightspath,
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -113,7 +113,6 @@ def downscale(
         yclimofine,
         out,
         af,
-        storage=_authenticate_storage(),
         train_variable=trainvariable,
         out_variable=outvariable,
         method=method,

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -81,25 +81,14 @@ def biascorrect(x, xtrain, trainvariable, ytrain, out, outvariable, method):
 @dodola_cli.command(help="Downscale bias-corrected GCM")
 @click.argument("x", required=True)
 @click.option("--trainvariable", "-tv", required=True)
-@click.option(
-    "--yclimocoarse", "-ycc", required=True, help="Coarse resolution obs climatology"
-)
-@click.option(
-    "--yclimofine", "-ycf", required=True, help="Fine resolution obs climatology"
-)
+@click.option("--yclimocoarse", "-ycc", required=True)
+@click.option("--yclimofine", "-ycf", required=True)
 @click.option("--out", "-o", required=True)
 @click.option("--outvariable", "-ov", required=True)
-@click.argument("--method", "-m", required=True, help="Downscaling method")
-@click.option("--domain-file", "-d", required=True, help="Domain file to regrid to")
-@click.option(
-    "--adjustmentfactors", "-af", default=None, help="Outpath for adjustment factors"
-)
-@click.option(
-    "--weightspath",
-    "-w",
-    default=None,
-    help="Local path to existing regrid weights file",
-)
+@click.option("--method", "-m", required=True)
+@click.option("--domain_file", "-d", required=True)
+@click.option("--adjustmentfactors", "-af", default=None, required=False)
+@click.option("--weightspath", "-w", default=None, required=False)
 def downscale(
     x,
     trainvariable,
@@ -115,9 +104,9 @@ def downscale(
     """Downscale bias corrected GCM to 'out' based on obs climo (yclimocoarse, yclimofine) using (method) and (domain_file)"""
     services.downscale(
         x,
-        yclimocoarse=yclimocoarse,
-        yclimofine=yclimofine,
-        out=out,
+        yclimocoarse,
+        yclimofine,
+        out,
         train_variable=trainvariable,
         out_variable=outvariable,
         method=method,

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -3,8 +3,7 @@
 Math stuff and business logic goes here. This is the "business logic".
 """
 
-from skdownscale.pointwise_models import PointWiseDownscaler, BcsdTemperature
-from skdownscale.spatial_models import SpatialDisaggregator, apply_weights
+from skdownscale.spatial_models import SpatialDisaggregator
 import xarray as xr
 from xclim import sdba
 from xclim.core.calendar import convert_calendar
@@ -41,8 +40,11 @@ def apply_bias_correction(
         variable name used in downscaled output
     method : {"QDM"}
         method to be used in the applied bias correction
-    ds_predicted : Dataset
-        bias corrected future model data
+
+    Returns
+    -------
+    ds_predicted : xr.Dataset
+        Dataset that has been bias corrected.
     """
 
     if method == "QDM":
@@ -78,26 +80,28 @@ def apply_downscaling(
     Parameters
     ----------
     bc_ds : Dataset
-        bias corrected model data
+        Model data that has already been bias corrected.
     obs_climo_coarse : Dataset
-        observation climatologies at coarse resolution
+        Observation climatologies at coarse resolution.
     obs_climo_fine : Dataset
-        observation climatologies at fine resolution
+        Observation climatologies at fine resolution.
     train_variable : str
-        variable name used in obs data
+        Variable name used in obs data.
     out_variable : str
-        variable name used in downscaled output
+        Variable name used in downscaled output.
     method : {"BCSD"}
-        method to be used in the applied downscaling
+        Vethod to be used in the applied downscaling.
     domain_fine : Dataset
-        domain that specifies the fine resolution grid to downscale to
-    weights_path : str, optional
-        path to the weights file if they will be used in regridding,
-        weights for downscaling to fine resolution
-    ds_downscaled : Dataset
-        downscaled model data
-    adjustment_factors : Dataset
-        adjustment factors produced in downscaling
+        Domain that specifies the fine resolution grid to downscale to.
+    weights_path : str or None, optional
+        Path to the weights file, used for downscaling to fine resolution.
+
+    Returns
+    -------
+    af_fine : xr.Dataset
+        A dataset of adjustment factors at fine resolution used in downscaling.
+    ds_downscaled : xr.Dataset
+        A model dataset that has been downscaled from the bias correction resolution to specified domain file resolution.
     """
 
     if method == "BCSD":

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -25,7 +25,7 @@ def apply_bias_correction(
 
     """Bias correct input model data using specified method,
        using either monthly or +/- 15 day time grouping. Currently
-       BCSD and QDM methods are supported.
+       the QDM method is supported.
 
     Parameters
     ----------
@@ -39,20 +39,13 @@ def apply_bias_correction(
         variable name used in training data
     out_variable : str
         variable name used in downscaled output
-    method : {"BCSD", "QDM"}
+    method : {"QDM"}
         method to be used in the applied bias correction
     ds_predicted : Dataset
         bias corrected future model data
     """
 
-    if method == "BCSD":
-        # note that time_grouper='daily_nasa-nex' is what runs the
-        # NASA-NEX version of daily BCSD
-        # TO-DO: switch to NASA-NEX version once tests pass
-        model = PointWiseDownscaler(BcsdTemperature(return_anoms=False))
-        model.fit(gcm_training_ds[train_variable], obs_training_ds[train_variable])
-        predicted = model.predict(gcm_predict_ds[train_variable]).load()
-    elif method == "QDM":
+    if method == "QDM":
         # instantiates a grouper class that groups by day of the year
         # centered window: +/-15 day group
         group = sdba.Grouper("time.dayofyear", window=31)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -110,10 +110,13 @@ def apply_downscaling(
         af_fine = xesmf_regrid(af_coarse, domain_fine, "bilinear", weights_path)
 
         # apply adjustment factors
-        ds_downscaled = model.predict(af_fine, obs_climo_fine, var_name=train_variable)
+        predicted = model.predict(
+            af_fine, obs_climo_fine[train_variable], var_name=train_variable
+        )
     else:
         raise ValueError("this method is not supported")
 
+    ds_downscaled = predicted.to_dataset(name=out_variable)
     return af_fine, ds_downscaled
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -110,11 +110,10 @@ def apply_downscaling(
         af_fine = xesmf_regrid(af_coarse, domain_fine, "bilinear", weights_path)
 
         # apply adjustment factors
-        predicted = model.predict(af_fine, obs_climo_fine, var_name=train_variable)
+        ds_downscaled = model.predict(af_fine, obs_climo_fine, var_name=train_variable)
     else:
         raise ValueError("this method is not supported")
 
-    ds_downscaled = predicted.to_dataset(name=out_variable)
     return af_fine, ds_downscaled
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -21,7 +21,7 @@ def apply_bias_correction(
     train_variable,
     out_variable,
     method,
-    ):
+):
 
     """Bias correct input model data using specified method,
        using either monthly or +/- 15 day time grouping. Currently
@@ -76,16 +76,16 @@ def apply_downscaling(
     method,
     domain_fine,
     weights_path=None,
-    ):
+):
 
-    """Downscale input bias corrected data using specified method. 
-       Currently only the BCSD method for spatial disaggregation is 
+    """Downscale input bias corrected data using specified method.
+       Currently only the BCSD method for spatial disaggregation is
        supported.
 
     Parameters
     ----------
     bc_ds : Dataset
-        bias corrected model data 
+        bias corrected model data
     obs_climo_coarse : Dataset
         observation climatologies at coarse resolution
     obs_climo_fine : Dataset
@@ -97,9 +97,9 @@ def apply_downscaling(
     method : {"BCSD"}
         method to be used in the applied downscaling
     domain_fine : Dataset
-        domain that specifies the fine resolution grid to downscale to 
+        domain that specifies the fine resolution grid to downscale to
     weights_path : str, optional
-        path to the weights file if they will be used in regridding, 
+        path to the weights file if they will be used in regridding,
         weights for downscaling to fine resolution
     ds_downscaled : Dataset
         downscaled model data
@@ -111,13 +111,13 @@ def apply_downscaling(
         model = SpatialDisaggregator(var=train_variable)
         af_coarse = model.fit(bc_ds, obs_climo_coarse, var_name=train_variable)
 
-        # regrid adjustment factors 
-        # BCSD uses bilinear interpolation for both temperature and precip to 
-        # regrid adjustment factors 
-        af_fine = xesmf_regrid(af_coarse, domain_fine, 'bilinear', weights_path)
+        # regrid adjustment factors
+        # BCSD uses bilinear interpolation for both temperature and precip to
+        # regrid adjustment factors
+        af_fine = xesmf_regrid(af_coarse, domain_fine, "bilinear", weights_path)
 
         # apply adjustment factors
-        predicted = model.predict(af_fine, obs_climo_fine, var_name=train_variable
+        predicted = model.predict(af_fine, obs_climo_fine, var_name=train_variable)
     else:
         raise ValueError("this method is not supported")
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -8,6 +8,7 @@ from dodola.core import (
     xesmf_regrid,
     standardize_gcm,
     xclim_remove_leapdays,
+    apply_downscaling,
 )
 
 logger = logging.getLogger(__name__)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -123,7 +123,7 @@ def downscale(
         out_variable,
         method,
         domain_fine,
-        weights_path,
+        weights_path=weights_path,
     )
 
     storage.write(out, downscaled_ds)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -46,8 +46,6 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, method)
         bias-correction model.
     out : str
         Storage URL to write bias-corrected output to.
-    af : str
-        Storage URL to write fine-resolution adjustment factors to.
     out_variable : str
         Variable name used as output variable name.
     method : str
@@ -95,19 +93,19 @@ def downscale(
         Storage URL to input fine-res obs climatology to use for computing adjustment factors.
     out : str
         Storage URL to write downscaled output to.
-    adjustmentfactors : str, optional
+    adjustmentfactors : str or None, optional
         Storage URL to write fine-resolution adjustment factors to.
     train_variable : str
         Variable name used in training and obs data.
     out_variable : str
         Variable name used as output variable name.
-    method : str
+    method : {"BCSD"}
         Downscaling method to be used.
     domain_file : str
         Storage URL to input grid for regridding adjustment factors
     adjustmentfactors : str, optional
         Storage URL to write fine-resolution adjustment factors to.
-    weights_path : str, optional
+    weights_path : str or None, optional
         Storage URL for input weights for regridding
     """
     bc_ds = storage.read(x)
@@ -117,17 +115,18 @@ def downscale(
 
     adjustment_factors, downscaled_ds = apply_downscaling(
         bc_ds,
-        obs_climo_coarse,
-        obs_climo_fine,
-        train_variable,
-        out_variable,
-        method,
-        domain_fine,
+        obs_climo_coarse=obs_climo_coarse,
+        obs_climo_fine=obs_climo_fine,
+        train_variable=train_variable,
+        out_variable=out_variable,
+        method=method,
+        domain_fine=domain_fine,
         weights_path=weights_path,
     )
 
     storage.write(out, downscaled_ds)
-    storage.write(adjustmentfactors, adjustment_factors)
+    if adjustmentfactors is not None:
+        storage.write(adjustmentfactors, adjustment_factors)
 
 
 @log_service

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -76,12 +76,12 @@ def downscale(
     y_climo_coarse,
     y_climo_fine,
     out,
-    af,
     train_variable,
     out_variable,
     method,
     domain_file,
-    weights_path,
+    adjustmentfactors=None,
+    weights_path=None,
 ):
     """Downscale bias corrected model data with IO to storage
 
@@ -95,7 +95,7 @@ def downscale(
         Storage URL to input fine-res obs climatology to use for computing adjustment factors.
     out : str
         Storage URL to write downscaled output to.
-    af : str, optional
+    adjustmentfactors : str, optional
         Storage URL to write fine-resolution adjustment factors to.
     train_variable : str
         Variable name used in training and obs data.
@@ -105,6 +105,8 @@ def downscale(
         Downscaling method to be used.
     domain_file : str
         Storage URL to input grid for regridding adjustment factors
+    adjustmentfactors : str, optional
+        Storage URL to write fine-resolution adjustment factors to.
     weights_path : str, optional
         Storage URL for input weights for regridding
     """
@@ -125,7 +127,7 @@ def downscale(
     )
 
     storage.write(out, downscaled_ds)
-    storage.write(af, adjustment_factors)
+    storage.write(adjustmentfactors, adjustment_factors)
 
 
 @log_service

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -77,7 +77,6 @@ def downscale(
     y_climo_fine,
     out,
     af,
-    storage,
     train_variable,
     out_variable,
     method,
@@ -98,8 +97,6 @@ def downscale(
         Storage URL to write downscaled output to.
     af : str, optional
         Storage URL to write fine-resolution adjustment factors to.
-    storage : dodola.repository._ZarrRepo
-        Storage abstraction for data IO.
     train_variable : str
         Variable name used in training and obs data.
     out_variable : str

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -82,7 +82,6 @@ def domain_file(request):
     domain[lat_name] = np.unique(domain[lat_name].values)
     domain[lon_name] = np.unique(domain[lon_name].values)
 
-    domain = domain.drop(["lon_b", "lat_b"])
     return domain
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import pytest
-import pandas as pd
 import xarray as xr
 from xesmf.data import wave_smooth
 from xesmf.util import grid_global
@@ -374,7 +373,7 @@ def test_downscale(domain_file, method, var):
     ds_bc = ds_bc.rename({"x": lon_name, "y": lat_name})
     ds_bc[lat_name] = np.unique(ds_bc[lat_name].values)
     ds_bc[lon_name] = np.unique(ds_bc[lon_name].values)
-    time = pd.date_range(start_time, end_time, freq="D")
+    time = xr.cftime_range(start_time, end_time, freq="D")
     ds_bc[var] = xr.DataArray(
         np.random.randn(len(time), len(ds_bc["lat"]), len(ds_bc["lon"])),
         dims=("time", "lat", "lon"),
@@ -446,16 +445,17 @@ def test_downscale(domain_file, method, var):
     elif var == "precipitation":
         downscaled_test = af_fine.groupby("time.dayofyear") * climo_fine
 
+    # now actually test downscaling service (everything above was purely setup)
     downscale(
         ds_bc_url,
-        climo_coarse_url,
-        climo_fine_url,
-        downscaled_url,
-        var,
-        var,
-        method,
-        domain_file_url,
-        af_saved_url,
+        y_climo_coarse=climo_coarse_url,
+        y_climo_fine=climo_fine_url,
+        out=downscaled_url,
+        train_variable=var,
+        out_variable=var,
+        method=method,
+        domain_file=domain_file_url,
+        adjustmentfactors=af_saved_url,
         weights_path=None,
     )
     downscaled_ds = repository.read(downscaled_url)[var]

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pytest
+import pandas as pd
 import xarray as xr
 from xesmf.data import wave_smooth
 from xesmf.util import grid_global

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -461,9 +461,9 @@ def test_downscale(domain_file, method, var):
 
     # compute test downscaled values
     if var == "temperature":
-        downscaled_test = af_fine + climo_fine
+        downscaled_test = af_fine.groupby("time.dayofyear") + climo_fine
     elif var == "precipitation":
-        downscaled_test = af_fine * climo_fine
+        downscaled_test = af_fine.groupby("time.dayofyear") * climo_fine
 
     downscale(
         "a/biascorrected/path.zarr",

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -82,6 +82,7 @@ def domain_file(request):
     domain[lat_name] = np.unique(domain[lat_name].values)
     domain[lon_name] = np.unique(domain[lon_name].values)
 
+    domain = domain.drop(["lon_b", "lat_b"])
     return domain
 
 
@@ -395,30 +396,37 @@ def test_downscale(domain_file, method, var):
 
     ds_bc_url = "memory://test_downscale/a/biascorrected/path.zarr"
     repository.write(ds_bc_url, ds_bc)
+
     domain_file_url = "memory://test_downscale/a/domainfile/path.zarr"
     repository.write(domain_file_url, domain_file)
+
     climo_coarse_url = "memory://test_downscale/a/coarseclimo/path.zarr"
     repository.write(climo_coarse_url, climo_coarse)
+
     af_coarse_url = "memory://test_downscale/a/coarseaf/path.zarr"
     repository.write(af_coarse_url, af_coarse)
-    fine_climo_url = "memory://test_downscale/a/fineaf/path.zarr"
+
+    climo_fine_url = "memory://test_downscale/a/fineclimo/path.zarr"
+
     af_fine_url = "memory://test_downscale/a/fineaf/path.zarr"
+
     downscaled_url = "memory://test_downscale/a/downscaled/path.zarr"
+
     af_saved_url = "memory://test_downscale/a/afsaved/path.zarr"
 
     # regrid climatology to fine resolution
     regrid(
         climo_coarse_url,
-        out=fine_climo_url,
+        out=climo_fine_url,
         method="bilinear",
         domain_file=domain_file_url,
     )
-    climo_fine = repository.read(fine_climo_url)[var]
+    climo_fine = repository.read(climo_fine_url)[var]
 
     # regrid adjustment factor
     regrid(
         af_coarse_url,
-        out=af_fine_url,
+        af_fine_url,
         method="bilinear",
         domain_file=domain_file_url,
     )
@@ -433,7 +441,7 @@ def test_downscale(domain_file, method, var):
     downscale(
         ds_bc_url,
         climo_coarse_url,
-        fine_climo_url,
+        climo_fine_url,
         downscaled_url,
         af_saved_url,
         train_variable=var,

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -442,11 +442,11 @@ def test_downscale(domain_file, method, var):
         climo_coarse_url,
         climo_fine_url,
         downscaled_url,
+        var,
+        var,
+        method,
+        domain_file_url,
         af_saved_url,
-        train_variable=var,
-        out_variable=var,
-        method=method,
-        domain_file=domain_file_url,
         weights_path=None,
     )
     downscaled_ds = repository.read(downscaled_url)[var]

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -104,12 +104,6 @@ def domain_file(request):
             ),
             id="QDM head/tail",
         ),
-        pytest.param(
-            "BCSD",
-            np.array([-0.08129293, -0.07613746, -0.0709855, -0.0658377, -0.0606947]),
-            np.array([0.0520793, 0.06581804, 0.07096781, 0.07612168, 0.08127902]),
-            id="BCSD head/tail",
-        ),
     ],
 )
 def test_bias_correct_basic_call(method, expected_head, expected_tail):

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -398,8 +398,8 @@ def test_downscale(domain_file, method, var):
 
     # make fake bias corrected data
     res = 36
-    lat_name = 'lat'
-    lon_name = 'lon'
+    lat_name = "lat"
+    lon_name = "lon"
     ds_bc = grid_global(res, res)
     ds_bc = ds_bc.rename({"x": lon_name, "y": lat_name})
     ds_bc[lat_name] = np.unique(ds_bc[lat_name].values)
@@ -410,7 +410,7 @@ def test_downscale(domain_file, method, var):
         dims=("time", "lat", "lon"),
         coords={"time": time, "lat": ds_bc["lat"], "lon": ds_bc["lon"]},
     )
-    ds_bc = ds_bc.drop(['lon_b', 'lat_b'])
+    ds_bc = ds_bc.drop(["lon_b", "lat_b"])
 
     # make fake climatology at coarse res
     ds_for_climo = grid_global(res, res)
@@ -422,7 +422,9 @@ def test_downscale(domain_file, method, var):
         dims=("time", "lat", "lon"),
         coords={"time": time, "lat": ds_for_climo["lat"], "lon": ds_for_climo["lon"]},
     )
-    climo_coarse = ds_for_climo.groupby("time.dayofyear").mean().drop(['lon_b', 'lat_b'])
+    climo_coarse = (
+        ds_for_climo.groupby("time.dayofyear").mean().drop(["lon_b", "lat_b"])
+    )
 
     # compute adjustment factor
     if var == "temperature":

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -75,7 +75,7 @@ def _gcmfactory(x, start_time="1950-01-01"):
 
 @pytest.fixture
 def domain_file(request):
-    """ Creates a fake domain Dataset for testing"""
+    """Creates a fake domain Dataset for testing"""
     lon_name = "lon"
     lat_name = "lat"
     domain = grid_global(request.param, request.param)
@@ -306,7 +306,7 @@ def test_regrid_weights_integration(domain_file, tmpdir):
 
 
 def test_clean_cmip6():
-    """ Tests that cmip6 cleanup removes extra dimensions on dataset """
+    """Tests that cmip6 cleanup removes extra dimensions on dataset"""
     # Setup input data
     n = 1500  # need over four years of daily data
     ts = np.sin(np.linspace(-10 * np.pi, 10 * np.pi, n)) * 0.5
@@ -325,7 +325,7 @@ def test_clean_cmip6():
 
 
 def test_remove_leapdays():
-    """ Test that leapday removal service removes leap days """
+    """Test that leapday removal service removes leap days"""
     # Setup input data
     n = 1500  # need over four years of daily data
     ts = np.sin(np.linspace(-10 * np.pi, 10 * np.pi, n)) * 0.5

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,4 +17,4 @@ dependencies:
 - xclim
 - zarr
 - pip:
-  - git+https://github.com/dgergel/xsd@pointwisedownscaler_interimfix
+  - git+https://github.com/dgergel/xsd@feature/add_spatial_disaggregation_recipe


### PR DESCRIPTION
This PR adds a downscaling service (currently only spatial disaggregation) and removes the BCSD option from the bias correction service.

Basic interface from CLI is

```
dodola downscale /path/to/store.zarr \
    --trainvariable tasmax \
    --yclimocoarse /path/to/obsclimocoarse.zarr \
    --yclimofine /path/to/obsclimofine.zarr \
    --out /path/to/regrid.zarr \
    --outvariable tasmax \
    --method "BCSD" \
    --domain_file /path/to/domainfile/zarr \
    --adjustmentfactors /path/to/af.zarr
```

`--adjustmentfactors` is an optional argument to specify a path if the user wants to write adjustment factors to a zarr, and `weightspath` an optional argument to specify a path to weights if they have been precomputed for use in regridding from coarse to fine. 

closes #51 