### PR TITLE
add domain file functionality to buildweights

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-*
+* Update buildweights service to add support for regridding to domain file. Not backwards compatible. (PR#67, @dgergel)
 
 
 0.2.0 (2021-04-23)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -53,7 +53,7 @@ def cleancmip6(x, out, drop_leapdays):
 @click.argument("x", required=True)
 @click.argument("out", required=True)
 def removeleapdays(x, out):
-    """ Remove leap days and update calendar attribute"""
+    """Remove leap days and update calendar attribute"""
     services.remove_leapdays(x, out)
 
 
@@ -86,11 +86,9 @@ def biascorrect(x, xtrain, trainvariable, ytrain, out, outvariable, method):
     required=True,
     help="Regridding method - 'bilinear' or 'conservative'",
 )
-@click.option(
-    "--targetresolution", "-r", default=1.0, help="Global-grid resolution to regrid to"
-)
+@click.option("--domain-file", "-d", help="Domain file to regrid to")
 @click.option("--outpath", "-o", default=None, help="Local path to write weights file")
-def buildweights(x, method, targetresolution, outpath):
+def buildweights(x, method, domain_file, outpath):
     """Generate local NetCDF weights file for regridding a target climate dataset
 
     Note, the output weights file is only written to the local disk. See
@@ -101,7 +99,7 @@ def buildweights(x, method, targetresolution, outpath):
     services.build_weights(
         str(x),
         str(method),
-        target_resolution=float(targetresolution),
+        domain_file,
         outpath=str(outpath),
     )
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -66,16 +66,16 @@ def apply_bias_correction(
     return ds_predicted
 
 
-def build_xesmf_weights_file(x, method, target_resolution, filename=None):
+def build_xesmf_weights_file(x, domain, method, filename=None):
     """Build ESMF weights file for regridding x to a global grid
 
     Parameters
     ----------
     x : xr.Dataset
+    domain : xr.Dataset
+        Domain to regrid to.
     method : str
         Method of regridding. Passed to ``xesmf.Regridder``.
-    target_resolution: float
-        Decimal-degree resolution of global grid to regrid to.
     filename : optional
         Local path to output netCDF weights file.
 
@@ -86,7 +86,7 @@ def build_xesmf_weights_file(x, method, target_resolution, filename=None):
     """
     out = xe.Regridder(
         x,
-        xe.util.grid_global(target_resolution, target_resolution),
+        domain,
         method=method,
         filename=filename,
     )

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -68,7 +68,7 @@ def bias_correct(x, x_train, train_variable, y_train, out, out_variable, method)
 
 
 @log_service
-def build_weights(x, method, target_resolution=1.0, outpath=None):
+def build_weights(x, method, domain_file, outpath=None):
     """Generate local NetCDF weights file for regridding climate data
 
     Parameters
@@ -77,15 +77,16 @@ def build_weights(x, method, target_resolution=1.0, outpath=None):
         Storage URL to input xr.Dataset that will be regridded.
     method : str
         Method of regridding. Passed to ``xesmf.Regridder``.
-    target_resolution : float, optional
-        Decimal-degree resolution of global grid to regrid to.
+    domain_file : str
+        Storage URL to input xr.Dataset domain file to regrid to.
     outpath : optional
         Local file path name to write regridding weights file to.
     """
     ds = storage.read(x)
-    build_xesmf_weights_file(
-        ds, method=method, target_resolution=target_resolution, filename=outpath
-    )
+
+    ds_domain = storage.read(domain_file)
+
+    build_xesmf_weights_file(ds, ds_domain, method=method, filename=outpath)
 
 
 @log_service

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -1,4 +1,4 @@
-"""test application services
+"""Test application services
 """
 
 import numpy as np

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -1,4 +1,4 @@
-"""Test application services
+"""test application services
 """
 
 import numpy as np
@@ -74,7 +74,7 @@ def _gcmfactory(x, start_time="1950-01-01"):
 
 @pytest.fixture
 def domain_file(request):
-    """ Creates a fake domain Dataset for testing"""
+    """Creates a fake domain Dataset for testing"""
     lon_name = "lon"
     lat_name = "lat"
     domain = grid_global(request.param, request.param)
@@ -160,8 +160,12 @@ def test_bias_correct_basic_call(method, expected_head, expected_tail):
     )
 
 
-@pytest.mark.parametrize("regrid_method", ["bilinear", "conservative"])
-def test_build_weights(regrid_method, tmpdir):
+@pytest.mark.parametrize(
+    "domain_file, regrid_method",
+    [pytest.param(1.0, "bilinear"), pytest.param(1.0, "conservative")],
+    indirect=["domain_file"],
+)
+def test_build_weights(domain_file, regrid_method, tmpdir):
     """Test that services.build_weights produces a weights file"""
     # Output to tmp dir so we cleanup & don't clobber existing files...
     weightsfile = tmpdir.join("a_file_path_weights.nc")
@@ -170,10 +174,13 @@ def test_build_weights(regrid_method, tmpdir):
     ds_in = grid_global(30, 20)
     ds_in["fakevariable"] = wave_smooth(ds_in["lon"], ds_in["lat"])
 
+    domain_file_url = "memory://test_regrid_methods/a/domainfile/path.zarr"
+    repository.write(domain_file_url, domain_file)
+
     url = "memory://test_build_weights/a_file_path.zarr"
     repository.write(url, ds_in)
 
-    build_weights(url, method=regrid_method, outpath=weightsfile)
+    build_weights(url, regrid_method, domain_file_url, outpath=weightsfile)
     # Test that weights file is actually created where we asked.
     assert weightsfile.exists()
 
@@ -298,7 +305,9 @@ def test_regrid_weights_integration(domain_file, tmpdir):
     repository.write(domain_file_url, domain_file)
 
     # First, use service to pre-build regridding weights files, then read-in to regrid.
-    build_weights(in_url, method="bilinear", outpath=weightsfile)
+    build_weights(
+        in_url, method="bilinear", domain_file=domain_file_url, outpath=weightsfile
+    )
     regrid(
         in_url,
         out=out_url,
@@ -311,7 +320,7 @@ def test_regrid_weights_integration(domain_file, tmpdir):
 
 
 def test_clean_cmip6():
-    """ Tests that cmip6 cleanup removes extra dimensions on dataset """
+    """Tests that cmip6 cleanup removes extra dimensions on dataset"""
     # Setup input data
     n = 1500  # need over four years of daily data
     ts = np.sin(np.linspace(-10 * np.pi, 10 * np.pi, n)) * 0.5
@@ -330,7 +339,7 @@ def test_clean_cmip6():
 
 
 def test_remove_leapdays():
-    """ Test that leapday removal service removes leap days """
+    """Test that leapday removal service removes leap days"""
     # Setup input data
     n = 1500  # need over four years of daily data
     ts = np.sin(np.linspace(-10 * np.pi, 10 * np.pi, n)) * 0.5


### PR DESCRIPTION
This PR adds domain file functionality to the `build_weights` service and is _not_ backwards compatible with previous versions of the service. 

CLI interface is now: 
```
dodola buildweights <inputfile_url> -m "bilinear" --domain_file <domain_file_url> --output /new-weightsfile.nc
```

closes #49 