### PR TITLE
Add QDM workflow components

### DIFF
--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -36,6 +36,14 @@ def dodola_cli(debug):
     logging.basicConfig(level=loglevel)
 
 
+@dodola_cli.command(help="Find range of QDM rolling-year window")
+@click.argument("x")
+@click.option("--out", "-o", help="URL to write JSON output to")
+def find_qdm_ryw(x, out):
+    """Write first and last year of QDM rolling-year window for (x) to JSON (out)"""
+    services.remove_leapdays(x, out)
+
+
 @dodola_cli.command(help="Clean up and standardize GCM")
 @click.argument("x", required=True)
 @click.argument("out", required=True)

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -6,13 +6,14 @@ import dodola.services
 
 @pytest.mark.parametrize(
     "subcmd",
-    [None, "biascorrect", "buildweights", "rechunk", "regrid"],
+    [None, "biascorrect", "buildweights", "rechunk", "regrid", "find-qdm-ryw"],
     ids=(
         "--help",
         "biascorrect --help",
         "buildweights --help",
         "rechunk --help",
         "regrid --help",
+        "find-qdm-ryw --help",
     ),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+import xarray as xr
+from dodola.core import qdm_rollingyearwindow
+
+
+@pytest.mark.parametrize(
+    "in_dts, goalyears",
+    [
+        pytest.param(("2015-01-01", "2100-01-01"), (2026, 2088), id="early start, early end"),
+        pytest.param(("2015-12-25", "2100-01-01"), (2027, 2088), id="late start, early end"),
+        pytest.param(("2015-01-01", "2100-02-01"), (2026, 2089), id="early start, late end"),
+    ]
+)
+def test_qdm_rollingyearwindow(in_dts, goalyears):
+    """Test qdm_rollingyearwindow ensures account for have 15 day buffer in edge years"""
+    # Create test data
+    t = xr.cftime_range(start=in_dts[0], end=in_dts[1], freq="D", calendar="noleap")
+    x = np.ones(len(t))
+    in_ds = xr.Dataset({"fakevariable": (["time"], x)}, coords={"time": t})
+
+    actual_first, actual_last = qdm_rollingyearwindow(in_ds)
+
+    assert actual_first == goalyears[0]
+    assert actual_last == goalyears[1]


### PR DESCRIPTION
This PR:

- Adds `dodola find-qdm-ryw az://simulation.zarr --out qdm-year-range.json`, using new `dodola.services.find_qdm_rollingyearwindow()`. This gets the first and last year for a simulation to adjust with quantile delta mapping (QDM) bias correction. The output years account for a ± 10 year window and 15 days at the start/end of the edge years. The command outputs to a JSON file to be read by Argo Workflows for its parallel "fan-out" step in the bias correction workflow. The JSON file looks like `{"firstyear": <int earliest year>, "lastyear": <int latest year>}`.

Close #66