### PR TITLE
Make runs easier to debug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM continuumio/miniconda3:4.9.2
 
 ENV PATH /opt/conda/bin:$PATH
+ENV PYTHONUNBUFFERED TRUE
 RUN conda install mamba -c conda-forge && conda clean --all
 
 # Copy only app requirements to cache dependencies

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 ------------------
 * Update buildweights service to add support for regridding to domain file. Not backwards compatible. (PR#67, @dgergel)
 * Add downscaling service. Currently support BCSD spatial disaggregation as implemented in scikit-downscale. (PR#65, @dgergel)
+* Remove stdout buffering from container runs, add IO debug logging. (PR#72, @brews)
 
 0.2.0 (2021-04-23)
 ------------------

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -20,6 +20,7 @@ def read(url_or_path):
     -------
     xr.Dataset
     """
+    logger.debug(f"Reading {url_or_path}")
     x = open_zarr(url_or_path)
     logger.info(f"Read {url_or_path}")
     return x
@@ -37,5 +38,6 @@ def write(url_or_path, x):
         Location to write Zarr store to.
     x : xr.Dataset
     """
+    logger.debug(f"Writing {url_or_path}")
     x.to_zarr(url_or_path, mode="w", compute=True)
     logger.info(f"Written {url_or_path}")


### PR DESCRIPTION
Minor additions to make runs easier to debug.

- When run in "debug" mode, will log any path/URL to be opened or written to, before any attempt is made. -- This is helpful because bad zarr paths are not printed in error messages.
- Remove stdout buffering from running Docker container by default.