### PR TITLE
Drop indirect dependency pin

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -14,7 +14,6 @@ dependencies:
 - s3fs
 - xarray=0.17.0 # Pinned for bug in dodola.services.rechunk
 - xesmf
-- esmpy=8.0.1=nompi_py38h5410a82_2  # Not direct dep. Dep of xesmf.
 - bottleneck
 - xclim
 - zarr


### PR DESCRIPTION
This removed esmpy pin was required for xesmf to function. Several updates and builds have been released since.