### PR TITLE
Release fsspec and adlfs pins for recent patches

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -2,10 +2,10 @@ name: base
 channels:
 - conda-forge
 dependencies:
-- adlfs=0.6
+- adlfs
 - click
 - cftime
-- fsspec=0.8.7 # Pinned req. for adlfs < 0.7
+- fsspec
 - gcsfs
 - numpy
 - pip


### PR DESCRIPTION
This pin was set to fix zarr and compatibility trouble from significant changes in fsspec and adlfs. Several releases have been made to these packages since this incompatibility so the pin is likely no longer needed.