### PR TITLE
add wet day frequency correction

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ History
 * Remove stdout buffering from container runs, add IO debug logging. (PR #72, @brews)
 * Add bias-correction quantile delta mapping (QDM) components to support Argo Workflows. New commands added: ``dodola train-qdm`` and ``dodola apply-qdm``. (PR #70, @brews)
 * Fix CMIP6 clean to better handle coords vs dims. (PR #81, @brews)
+* Add wet day frequency correction service. Wet day frequency implemented as described in Cannon et al., 2015. New command added: ``dodola correct-wetday-frequency``. (PR #78, @dgergel)
 
 0.2.0 (2021-04-23)
 ------------------

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -191,3 +191,18 @@ def regrid(x, out, method, domain_file, weightspath):
         domain_file=domain_file,
         weights_path=weightspath,
     )
+
+
+@dodola_cli.command(help="Correct wet day frequency in a dataset")
+@click.argument("x", required=True)
+@click.option("--out", "-o", required=True)
+@click.option(
+    "--process",
+    "-p",
+    required=True,
+    type=click.Choice(["pre-process", "post-process"], case_sensitive=False),
+    help="Whether to pre or post process wet day frequency",
+)
+def correct_wetday_frequency(x, out, process):
+    """Correct wet day frequency in a dataset"""
+    services.correct_wet_day_frequency(str(x), out=str(out), process=str(process))

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -245,7 +245,7 @@ def regrid(x, out, method, domain_file, weightspath):
     "--process",
     "-p",
     required=True,
-    type=click.Choice(["pre-process", "post-process"], case_sensitive=False),
+    type=click.Choice(["pre", "post"], case_sensitive=False),
     help="Whether to pre or post process wet day frequency",
 )
 def correct_wetday_frequency(x, out, process):

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -334,6 +334,10 @@ def apply_wet_day_frequency_correction(ds, process):
     Returns
     -------
     xr.Dataset
+
+    Notes
+    -------
+    [1] A.J. Cannon, S.R. Sobie, & T.Q. Murdock, "Bias correction of GCM precipitation by quantile mapping: How well do methods preserve changes in quantiles and extremes?", Journal of Climate, vol. 28, Issue 7, pp. 6938-6959.
     """
     threshold = 0.05  # mm/day
     low = 1e-16

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -329,7 +329,7 @@ def apply_wet_day_frequency_correction(ds, process):
     Parameters
     ----------
     ds : xr.Dataset
-    process : {"pre-process", "post-process"}
+    process : {"pre", "post"}
 
     Returns
     -------
@@ -341,9 +341,9 @@ def apply_wet_day_frequency_correction(ds, process):
     """
     threshold = 0.05  # mm/day
     low = 1e-16
-    if process == "pre-process":
+    if process == "pre":
         ds_corrected = ds.where(ds != 0.0, np.random.uniform(low=low, high=threshold))
-    elif process == "post-process":
+    elif process == "post":
         ds_corrected = ds.where(ds >= threshold, 0.0)
     else:
         raise ValueError("this processing option is not implemented")

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -329,7 +329,7 @@ def apply_wet_day_frequency_correction(ds, process):
     Parameters
     ----------
     ds : xr.Dataset
-    process : str
+    process : {"pre-process", "post-process"}
 
     Returns
     -------

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -3,6 +3,7 @@
 Math stuff and business logic goes here. This is the "business logic".
 """
 
+import numpy as np
 from skdownscale.spatial_models import SpatialDisaggregator
 import xarray as xr
 from xclim import sdba
@@ -231,3 +232,26 @@ def xclim_remove_leapdays(ds):
     """
     ds_noleap = convert_calendar(ds, target="noleap")
     return ds_noleap
+
+
+def apply_wet_day_frequency_correction(ds, process):
+    """
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+    process : str
+
+    Returns
+    -------
+    xr.Dataset
+    """
+    threshold = 0.05  # mm/day
+    low = 1e-16
+    if process == "pre-process":
+        ds_corrected = ds.where(ds != 0.0, np.random.uniform(low=low, high=threshold))
+    elif process == "post-process":
+        ds_corrected = ds.where(ds >= threshold, 0.0)
+    else:
+        raise ValueError("this processing option is not implemented")
+    return ds_corrected

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -9,6 +9,7 @@ from dodola.core import (
     standardize_gcm,
     xclim_remove_leapdays,
     apply_downscaling,
+    apply_wet_day_frequency_correction,
 )
 import dodola.repository as storage
 
@@ -242,6 +243,24 @@ def remove_leapdays(x, out):
     ds = storage.read(x)
     noleap_ds = xclim_remove_leapdays(ds)
     storage.write(out, noleap_ds)
+
+
+@log_service
+def correct_wet_day_frequency(x, out, process):
+    """Corrects wet day frequency in a dataset
+
+    Parameters
+    ----------
+    x : str
+        Storage URL to input xr.Dataset that will be regridded.
+    out : str
+        Storage URL to write regridded output to.
+    process : {"pre-process", "post-process"}
+        Step in pipeline, used in determining how to correct.
+    """
+    ds = storage.read(x)
+    ds_corrected = apply_wet_day_frequency_correction(ds, process=process)
+    storage.write(out, ds_corrected)
 
 
 @log_service

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -329,8 +329,10 @@ def correct_wet_day_frequency(x, out, process):
         Storage URL to input xr.Dataset that will be regridded.
     out : str
         Storage URL to write regridded output to.
-    process : {"pre-process", "post-process"}
-        Step in pipeline, used in determining how to correct. If pre-process, replaces all zero values with a uniform random value below a threshold. If post-process, replaces all values below a threshold with zeroes. Pre-process occurs before bias correction and downscaling, post-process occurs after.
+    process : {"pre", "post"}
+        Step in pipeline, used in determining how to correct.
+        "Pre" replaces all zero values with a uniform random value below a threshold (before bias correction).
+        "Post" replaces all values below a threshold with zeroes (after bias correction).
     """
     ds = storage.read(x)
     ds_corrected = apply_wet_day_frequency_correction(ds, process=process)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -330,7 +330,7 @@ def correct_wet_day_frequency(x, out, process):
     out : str
         Storage URL to write regridded output to.
     process : {"pre-process", "post-process"}
-        Step in pipeline, used in determining how to correct.
+        Step in pipeline, used in determining how to correct. If pre-process, replaces all zero values with a uniform random value below a threshold. If post-process, replaces all values below a threshold with zeroes. Pre-process occurs before bias correction and downscaling, post-process occurs after.
     """
     ds = storage.read(x)
     ds_corrected = apply_wet_day_frequency_correction(ds, process=process)

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -14,6 +14,7 @@ import dodola.services
         "regrid",
         "train-qdm",
         "apply-qdm",
+        "correct-wetday-frequency",
     ],
     ids=(
         "--help",
@@ -23,6 +24,7 @@ import dodola.services
         "regrid --help",
         "train-qdm --help",
         "apply-qdm --help",
+        "correct-wetday-frequency --help",
     ),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -358,7 +358,7 @@ def test_remove_leapdays():
 def test_correct_wet_day_frequency(process):
     """Test that wet day frequency correction corrects the frequency of wet days"""
     # Make some fake precip data
-    n = 1500
+    n = 700
     threshold = 0.05
     ts = np.linspace(0.0, 10, num=n)
     ds_precip = _datafactory(ts, start_time="1950-01-01")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -442,9 +442,7 @@ def test_remove_leapdays():
     assert len(ds_leapyear.time) == 365
 
 
-@pytest.mark.parametrize(
-    "process", [pytest.param("pre-process"), pytest.param("post-process")]
-)
+@pytest.mark.parametrize("process", [pytest.param("pre"), pytest.param("post")])
 def test_correct_wet_day_frequency(process):
     """Test that wet day frequency correction corrects the frequency of wet days"""
     # Make some fake precip data
@@ -459,7 +457,7 @@ def test_correct_wet_day_frequency(process):
     correct_wet_day_frequency(in_url, out=out_url, process=process)
     ds_precip_corrected = repository.read(out_url)
 
-    if process == "pre-process":
+    if process == "pre":
         # all 0 values should have been set to a random uniform value below 0.05
         assert (
             ds_precip_corrected["fakevariable"].where(
@@ -473,7 +471,7 @@ def test_correct_wet_day_frequency(process):
             )
             < threshold
         )
-    elif process == "post-process":
+    elif process == "post":
         # all values below 0.05 should be reset to 0
         assert (
             ds_precip_corrected["fakevariable"]


### PR DESCRIPTION
This PR adds a wet day frequency correction service. 

The wet day frequency method follows the Cannon et al 2015 method: motivated by the mixed discrete continuous nature of precip data, dry days are treated as values below a set threshold (in that paper, 0.05 mm/day). Zero values in the observed and modeled data are replaced with nonzero uniform random values below the threshold before bias correction; after bias correction (and downscaling in our case), all values below the threshold are set to zero. The pre and post bias correction options are denoted here with `pre-process` and `post-process` CLI options. 

Basic CLI interface is: 

```
dodola correct-wetday-frequency /path/to/store.zarr \
    --out /path/to/corrected.zarr \
    --process "pre-process" / "post-process"
```

closes #40 
