### PR TITLE
Bump xclim@sdba-ufunc version to latest commit

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -18,4 +18,4 @@ dependencies:
 - zarr
 - pip:
   - git+https://github.com/dgergel/xsd@feature/add_spatial_disaggregation_recipe
-  - git+https://github.com/Ouranosinc/xclim@92ba9f1fb2f45dd65c52fd35fbfff9d80ac9ee54  #spec commit from @sdba-ufunc
+  - git+https://github.com/Ouranosinc/xclim@6bfb8028a148f11afab954e5138f7de820f8860e  #spec commit from @sdba-ufunc


### PR DESCRIPTION
This PR updates our pin on the `xclim@sdba-ufunc` to grab the most recent commit.

We don't need this bump for a specific new feature or bug fix, but we want to track and test the latest updates to this branch.