### PR TITLE
Pin commit ref to xsd fork branch dependency

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -18,5 +18,5 @@ dependencies:
 - bottleneck
 - zarr
 - pip:
-  - git+https://github.com/dgergel/xsd@feature/add_spatial_disaggregation_recipe
+  - git+https://github.com/dgergel/xsd@feature/add_spatial_disaggregation_recipe@458f292dab6e8a6584659e97a66c37e028da2b7a
   - git+https://github.com/Ouranosinc/xclim@d1e654cf59a5d5761f5586bca1102a1590ae6e32


### PR DESCRIPTION
This pins a dependency that did not previously have a pin. We're pinning it because we want to be deliberate about when it updates.

This PR should have no change on the package or docker image.