### PR TITLE
Update docker environment's dask install

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - adlfs
-- dask=2021.4.1  # We don't directly depend on this, pinning so it doesn't break xarray=v0.18.0
+- dask
 - click
 - cftime
 - fsspec


### PR DESCRIPTION
We pinned to a previous release of the `dask` package because it broke recent releases of `xarray`. With recent upgrades to the current release of `xarray` and `dask` should be compatible. This PR unpins `dask` so we can test on the latest release of the package before we do a new release.