### PR TITLE
Add dask-kubernetes, distributed, and better subprocess handling in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,6 @@ RUN mamba env update -n base -f /opt/dodola/environment.yaml \
 
 COPY . /opt/dodola
 RUN bash -c "pip install -e /opt/dodola"
+
+# For graceful children and death.
+ENTRYPOINT ["tini", "-g", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM continuumio/miniconda3:4.9.2
 
 ENV PATH /opt/conda/bin:$PATH
 ENV PYTHONUNBUFFERED TRUE
-RUN conda install mamba -c conda-forge && conda clean --all
+RUN conda install mamba=0.14.0 tini=0.19.0 -c conda-forge && conda clean --all
 
 # Copy only app requirements to cache dependencies
 RUN mkdir /opt/dodola

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN mamba env update -n base -f /opt/dodola/environment.yaml \
 COPY . /opt/dodola
 RUN bash -c "pip install -e /opt/dodola"
 
+CMD ["dodola"]
+
 # For graceful children and death.
 ENTRYPOINT ["tini", "-g", "--"]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-*
+* Add ``dask-kubernetes``, ``distributed`` to container environment.
+* Improve subprocess and death handling in Docker container.
 
 
 0.3.0 (2021-06-16)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,9 +5,9 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Make ``dodola`` container's default CMD.
-* Add ``dask-kubernetes``, ``distributed`` to container environment.
-* Improve subprocess and death handling in Docker container.
+* Make ``dodola`` container's default CMD. (PR #90, @brews)
+* Add ``dask-kubernetes``, ``distributed`` to container environment. (PR #90, @brews)
+* Improve subprocess and death handling in Docker container. (PR #90, @brews)
 
 
 0.3.0 (2021-06-16)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
+* Make ``dodola`` container's default CMD.
 * Add ``dask-kubernetes``, ``distributed`` to container environment.
 * Improve subprocess and death handling in Docker container.
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,6 +4,8 @@ channels:
 dependencies:
 - adlfs=0.7.5  # Prevent azure blob errors, not hard req.
 - dask=2021.6.0
+- distributed=2021.6.0  # Not direct dodola dependency. Used in prototypes.
+- dask-kubernetes=2021.3.1  # Not direct dodola dependency. Used in prototypes.
 - click=8.0.1
 - cftime=1.5.0
 - fsspec=2021.5.0  # Prevent azure blob errors, not hard req.


### PR DESCRIPTION
Couple nuts-n-bolts changes here:

* Makes the `dodola` command the container's default CMD. This is just sugar when running the `dodola` container. By default, it'll now assume that you're running the `dodola` command unless you say otherwise.
* Adds `dask-kubernetes`, `distributed` to container environment. So these are not always installed from scratch. They're starting to get used in prototype workflows.
* Improves subprocess, signal, and death handling in Docker container — this is important as we start to do more process-heavy prototypes.

Close #89