### PR TITLE
Add precip unit conversion

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
+* Add precipitation unit conversion to ``standardize_gcm``. (PR #94, @dgergel)
 * Add ``astype`` argument to ``regrid``. (PR #92, @brews)
 * Make ``dodola`` container's default CMD. (PR #90, @brews)
 * Add ``dask-kubernetes``, ``distributed`` to container environment. (PR #90, @brews)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -298,7 +298,7 @@ def standardize_gcm(ds, leapday_removal=True):
 
     # Cleanup time.
 
-    # if variable is precip, need to update units to mm/day
+    # if variable is precip, need to update units to mm day-1
     if "pr" in ds_cleaned.variables:
         # units should be kg/m2/s in CMIP6 output
         if ds_cleaned["pr"].units == "kg m-2 s-1":
@@ -306,10 +306,10 @@ def standardize_gcm(ds, leapday_removal=True):
             mmday_conversion = 24 * 60 * 60
             ds_cleaned["pr"] = ds_cleaned["pr"] * mmday_conversion
             # update units attribute
-            ds_cleaned["pr"].attrs["units"] = "mm/day"
+            ds_cleaned["pr"].attrs["units"] = "mm day-1"
         else:
             # we want this to fail, as pr units are something we don't expect
-            raise AssertionError("check units: pr units attribute is not kg m-2 s-1")
+            raise ValueError("check units: pr units attribute is not kg m-2 s-1")
 
     if leapday_removal:
         # if calendar is just integers, xclim cannot understand it

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -299,17 +299,16 @@ def standardize_gcm(ds, leapday_removal=True):
     # Cleanup time.
 
     # if variable is precip, need to update units to mm/day
-    if "pr" in ds_cleaned.variables: 
-        # units should be kg/m2/s in CMIP6 output 
+    if "pr" in ds_cleaned.variables:
+        # units should be kg/m2/s in CMIP6 output
         if ds_cleaned["pr"].units == "kg m-2 s-1":
-            # convert to mm/day 
+            # convert to mm/day
             mmday_conversion = 24 * 60 * 60
             ds_cleaned["pr"] = ds_cleaned["pr"] * mmday_conversion
-            ds_cleaned["pr"].units = "mm/day" 
             # update units attribute
             ds_cleaned["pr"].attrs["units"] = "mm/day"
-        else: 
-            # we want this to fail, as pr units are something we don't expect 
+        else:
+            # we want this to fail, as pr units are something we don't expect
             raise AssertionError("check units: pr units attribute is not kg m-2 s-1")
 
     if leapday_removal:

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -297,6 +297,21 @@ def standardize_gcm(ds, leapday_removal=True):
     )
 
     # Cleanup time.
+
+    # if variable is precip, need to update units to mm/day
+    if "pr" in ds_cleaned.variables: 
+        # units should be kg/m2/s in CMIP6 output 
+        if ds_cleaned["pr"].units == "kg m-2 s-1":
+            # convert to mm/day 
+            mmday_conversion = 24 * 60 * 60
+            ds_cleaned["pr"] = ds_cleaned["pr"] * mmday_conversion
+            ds_cleaned["pr"].units = "mm/day" 
+            # update units attribute
+            ds_cleaned["pr"].attrs["units"] = "mm/day"
+        else: 
+            # we want this to fail, as pr units are something we don't expect 
+            raise AssertionError("check units: pr units attribute is not kg m-2 s-1")
+
     if leapday_removal:
         # if calendar is just integers, xclim cannot understand it
         if ds.time.dtype == "int64":

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -74,6 +74,11 @@ def _gcmfactory(x, gcm_variable="fakevariable", start_time="1950-01-01"):
             "time_bnds": (["time", "bnds"], np.ones((len(x), 2))),
         },
     )
+
+    if gcm_variable == "pr":
+        # assign units to typical GCM pr units so they can be cleaned
+        out["pr"].attrs["units"] = "kg m-2 s-1"
+
     return out
 
 
@@ -442,10 +447,13 @@ def test_regrid_weights_integration(domain_file, tmpdir):
     actual_shape = repository.read(out_url)["fakevariable"].shape
     assert actual_shape == expected_shape
 
-@pytest.mark.parametrize("gcm_variable", [pytest.param("tasmax"), pytest.param("tasmin"), pytest.param("pr")])
+
+@pytest.mark.parametrize(
+    "gcm_variable", [pytest.param("tasmax"), pytest.param("tasmin"), pytest.param("pr")]
+)
 def test_clean_cmip6(gcm_variable):
     """Tests that cmip6 cleanup removes extra dimensions on dataset
-       and that precip units are converted if variable is precip"""
+    and that precip units are converted if variable is precip"""
     # Setup input data
     n = 1500  # need over four years of daily data
     ts = np.sin(np.linspace(-10 * np.pi, 10 * np.pi, n)) * 0.5
@@ -462,7 +470,7 @@ def test_clean_cmip6(gcm_variable):
     assert "member_id" not in ds_cleaned.coords
     assert "time_bnds" not in ds_cleaned.coords
 
-    if "pr" in ds_cleaned.variables: 
+    if "pr" in ds_cleaned.variables:
         assert ds_cleaned["pr"].units == "mm/day"
 
 


### PR DESCRIPTION
This PR adds a units conversion for precip to the CMIP6 cleaning service and updates the test suite a bit such that the unit conversion can be tested. 

closes #93 