### PR TITLE
Add analog downscaling prototype

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ History
 
 0.x.x (xxxx-xx-xx)
 ------------------
-* Add AIQPD downscaling method to options. This supersedes the BCSD downscaling service. (PR #98, @dgergel) 
+* Add AIQPD downscaling method to options. Also updates xclim dependency to the CIL forked branch "add_analog_downscaling", with 0.28.1 of xclim merged in. 
+  This supersedes the BCSD downscaling service. (PR #98, @dgergel) 
 
 
 0.4.1 (2021-07-13)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.x.x (xxxx-xx-xx)
 ------------------
-* 
+* Add AIQPD downscaling method to options. This supersedes the BCSD downscaling service. (PR #98, @dgergel) 
 
 
 0.4.1 (2021-07-13)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -122,10 +122,10 @@ def apply_aiqpd(simulation, aiqpd, year, variable, out):
     help="Train analog-inspired quantile preserving downscaling (AIQPD)"
 )
 @click.option(
-    "--coarse_reference", "-cr", required=True, help="URL to coarse reference store"
+    "--coarse-reference", "-cr", required=True, help="URL to coarse reference store"
 )
 @click.option(
-    "--fine_reference", "-fr", required=True, help="URL to fine reference store"
+    "--fine-reference", "-fr", required=True, help="URL to fine reference store"
 )
 @click.option("--variable", "-v", required=True, help="Variable name in data stores")
 @click.option(

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -91,11 +91,18 @@ def train_qdm(historical, reference, out, variable, kind):
     )
 
 
-@dodola_cli.command(help="Adjust (downscale) simulation year with analog-inspired quantile preserving downscaling (AIQPD)")
+@dodola_cli.command(
+    help="Adjust (downscale) simulation year with analog-inspired quantile preserving downscaling (AIQPD)"
+)
 @click.option(
     "--simulation", "-s", required=True, help="URL to simulation store to adjust"
 )
-@click.option("--aiqpd", "-d", required=True, help="URL to trained AIQPD store of adjustment factors")
+@click.option(
+    "--aiqpd",
+    "-d",
+    required=True,
+    help="URL to trained AIQPD store of adjustment factors",
+)
 @click.option("--year", "-y", required=True, help="Year of simulation to adjust")
 @click.option("--variable", "-v", required=True, help="Variable name in data stores")
 @click.option(
@@ -110,11 +117,16 @@ def apply_aiqpd(simulation, aiqpd, year, variable, out):
         simulation=simulation, aiqpd=aiqpd, year=year, variable=variable, out=out
     )
 
-@dodola_cli.command(help="Train analog-inspired quantile preserving downscaling (AIQPD)")
+
+@dodola_cli.command(
+    help="Train analog-inspired quantile preserving downscaling (AIQPD)"
+)
 @click.option(
     "--coarse_reference", "-cr", required=True, help="URL to coarse reference store"
 )
-@click.option("--fine_reference", "-fr", required=True, help="URL to fine reference store")
+@click.option(
+    "--fine_reference", "-fr", required=True, help="URL to fine reference store"
+)
 @click.option("--variable", "-v", required=True, help="Variable name in data stores")
 @click.option(
     "--kind",
@@ -133,6 +145,7 @@ def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
         variable=variable,
         kind=kind,
     )
+
 
 @dodola_cli.command(help="Clean up and standardize GCM")
 @click.argument("x", required=True)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -81,6 +81,49 @@ def train_qdm(historical, reference, out, variable, kind):
     )
 
 
+@dodola_cli.command(help="Adjust (downscale) simulation year with analog-inspired quantile preserving downscaling (AIQPD)")
+@click.option(
+    "--simulation", "-s", required=True, help="URL to simulation store to adjust"
+)
+@click.option("--aiqpd", "-d", required=True, help="URL to trained AIQPD store of adjustment factors")
+@click.option("--year", "-y", required=True, help="Year of simulation to adjust")
+@click.option("--variable", "-v", required=True, help="Variable name in data stores")
+@click.option(
+    "--out",
+    "-o",
+    required=True,
+    help="URL to write NetCDF4 with adjusted (downscaled) simulation year to",
+)
+def apply_aiqpd(simulation, aiqpd, year, variable, out):
+    """Adjust simulation year with AIQPD downscaling method, outputting to local NetCDF4 file"""
+    services.apply_aiqpd(
+        simulation=simulation, aiqpd=aiqpd, year=year, variable=variable, out=out
+    )
+
+@dodola_cli.command(help="Train analog-inspired quantile preserving downscaling (AIQPD)")
+@click.option(
+    "--coarse_reference", "-cr", required=True, help="URL to coarse reference store"
+)
+@click.option("--fine_reference", "-fr", required=True, help="URL to fine reference store")
+@click.option("--variable", "-v", required=True, help="Variable name in data stores")
+@click.option(
+    "--kind",
+    "-k",
+    required=True,
+    type=click.Choice(["additive", "multiplicative"], case_sensitive=False),
+    help="Variable kind for mapping",
+)
+@click.option("--out", "-o", required=True, help="URL to write QDM model to")
+def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
+    """Train Analog-Inspired Quantile Preserving Downscaling (AIQPD) model and output to storage"""
+    services.train_aiqpd(
+        coarse_reference=coarse_reference,
+        fine_reference=fine_reference,
+        out=out,
+        variable=variable,
+        kind=kind,
+    )
+
 @dodola_cli.command(help="Clean up and standardize GCM")
 @click.argument("x", required=True)
 @click.argument("out", required=True)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -138,7 +138,7 @@ def train_analogdownscaling(
     aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling(
         kind=str(kind),
         group=sdba.Grouper("time.dayofyear", window=int(window_n)),
-        nquantiles=equally_spaced_nodes(int(quantiles_n), eps=None),
+        nquantiles=quantiles_n,
     )
     aiqpd.train(coarse_reference[variable], fine_reference[variable])
     return aiqpd

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -140,9 +140,7 @@ def train_analogdownscaling(
         group=sdba.Grouper("time.dayofyear", window=int(window_n)),
         nquantiles=equally_spaced_nodes(int(quantiles_n), eps=None),
     )
-    aiqpd.train(
-        coarse_reference[variable], fine_reference[variable]
-    )
+    aiqpd.train(coarse_reference[variable], fine_reference[variable])
     return aiqpd
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -135,6 +135,24 @@ def train_analogdownscaling(
     -------
     xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling
     """
+
+    # AIQPD method requires that the number of quantiles equals
+    # the number of days in each day group
+    # e.g. 20 years of data and a window of 31 = 620 quantiles
+
+    # check that lengths of input data are the same, then only check years for one
+    if len(coarse_reference.time) != len(fine_reference.time):
+        raise ValueError("coarse and fine reference data inputs have different lengths")
+
+    # check number of years in input data (subtract 2 for the +/- 15 days on each end)
+    num_years = len(np.unique(fine_reference.time.dt.year)) - 2
+    if (num_years * int(window_n)) != quantiles_n:
+        raise ValueError(
+            "number of quantiles {} must equal # of years {} * window length {}, day groups must {} days".format(
+                quantiles_n, num_years, int(window_n), quantiles_n
+            )
+        )
+
     aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling(
         kind=str(kind),
         group=sdba.Grouper("time.dayofyear", window=int(window_n)),

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -140,18 +140,19 @@ def train_analogdownscaling(
         group=sdba.Grouper("time.dayofyear", window=int(window_n)),
         nquantiles=equally_spaced_nodes(int(quantiles_n), eps=None),
     )
-    aiqpd.train(ref_coarse=coarse_reference[variable], ref_fine=fine_reference[variable])
+    aiqpd.train(
+        ref_coarse=coarse_reference[variable], ref_fine=fine_reference[variable]
+    )
     return aiqpd
 
-def adjust_analogdownscaling_year(
-    simulation, aiqpd, year, variable
-):
+
+def adjust_analogdownscaling_year(simulation, aiqpd, year, variable):
     """Apply AIQPD to downscale a year of bias corrected output.
 
     Parameters
     ----------
     simulation : xr.Dataset
-        Daily bias corrected data to be downscaled. 
+        Daily bias corrected data to be downscaled.
     aiqpd : xr.Dataset or sdba.adjustment.AnalogQuantilePreservingDownscaling
         Trained ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling``, or
         Dataset representation that will instantiate
@@ -171,20 +172,17 @@ def adjust_analogdownscaling_year(
     year = int(year)
     variable = str(variable)
 
-    if isinstance(qdm, xr.Dataset):
+    if isinstance(aiqpd, xr.Dataset):
         aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.from_dataset(aiqpd)
 
     # Slice to get 15 days before and after our target year. This accounts
     # for the rolling 31 day rolling window.
-    timeslice = slice(
-        f"{year}-01-01", f"{year}-12-31"
-    )
-    simulation = simulation[variable].sel(
-        time=timeslice
-    )  
+    timeslice = slice(f"{year}-01-01", f"{year}-12-31")
+    simulation = simulation[variable].sel(time=timeslice)
     out = aiqpd.adjust(simulation)
 
     return out.to_dataset(name=variable)
+
 
 def apply_bias_correction(
     gcm_training_ds,

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -101,6 +101,81 @@ def adjust_quantiledeltamapping_year(
     return out.to_dataset(name=variable)
 
 
+def train_analogdownscaling(
+    coarse_reference, fine_reference, variable, kind, quantiles_n=620, window_n=31
+):
+    """Train analog-inspired quantile-preserving downscaling
+
+    Parameters
+    ----------
+    coarse_reference : xr.Dataset
+        Dataset to use as resampled (to fine resolution) coarse reference.
+    fine_reference : xr.Dataset
+        Dataset to use as fine-resolution reference.
+    variable : str
+        Name of target variable to extract from `coarse_reference` and `fine_reference`.
+    kind : {"+", "*"}
+        Kind of variable. Used for creating AIQPD adjustment factors.
+    quantiles_n : int, optional
+        Number of quantiles for AIQPD.
+    window_n : int, optional
+        Centered window size for day-of-year grouping.
+
+    Returns
+    -------
+    xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling
+    """
+    aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling(
+        kind=str(kind),
+        group=sdba.Grouper("time.dayofyear", window=int(window_n)),
+        nquantiles=equally_spaced_nodes(int(quantiles_n), eps=None),
+    )
+    aiqpd.train(ref_coarse=coarse_reference[variable], ref_fine=fine_reference[variable])
+    return aiqpd
+
+def adjust_analogdownscaling_year(
+    simulation, aiqpd, year, variable
+):
+    """Apply AIQPD to downscale a year of bias corrected output.
+
+    Parameters
+    ----------
+    simulation : xr.Dataset
+        Daily bias corrected data to be downscaled. 
+    aiqpd : xr.Dataset or sdba.adjustment.AnalogQuantilePreservingDownscaling
+        Trained ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling``, or
+        Dataset representation that will instantiate
+        ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling``.
+    year : int
+        Target year to downscale, with day grouping.
+    variable : str
+        Target variable in `simulation` to downscale. Downscaled output will share the
+        same name.
+
+    Returns
+    -------
+    out : xr.Dataset
+        AIQPD-downscaled values from `simulation`. May be a lazy-evaluated future, not
+        yet computed.
+    """
+    year = int(year)
+    variable = str(variable)
+
+    if isinstance(qdm, xr.Dataset):
+        aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.from_dataset(aiqpd)
+
+    # Slice to get 15 days before and after our target year. This accounts
+    # for the rolling 31 day rolling window.
+    timeslice = slice(
+        f"{year}-01-01", f"{year}-12-31"
+    )
+    simulation = simulation[variable].sel(
+        time=timeslice
+    )  
+    out = aiqpd.adjust(simulation)
+
+    return out.to_dataset(name=variable)
+
 def apply_bias_correction(
     gcm_training_ds,
     obs_training_ds,

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -141,7 +141,7 @@ def train_analogdownscaling(
         nquantiles=equally_spaced_nodes(int(quantiles_n), eps=None),
     )
     aiqpd.train(
-        ref_coarse=coarse_reference[variable], ref_fine=fine_reference[variable]
+        coarse_reference[variable], fine_reference[variable]
     )
     return aiqpd
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -135,15 +135,17 @@ def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
     ref_fine = storage.read(fine_reference)
 
     kind_map = {"additive": "+", "multiplicative": "*"}
-    if kind not in kind_map.keys():
+    try:
+        k = kind_map[kind]
+    except KeyError:
         # So we get a helpful exception message showing accepted kwargs...
-        ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
+        raise ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
 
     aiqpd = train_analogdownscaling(
         coarse_reference=ref_coarse,
         fine_reference=ref_fine,
         variable=variable,
-        kind=kind_map[kind],
+        kind=k,
     )
 
     storage.write(out, aiqpd.ds)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -138,10 +138,14 @@ def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
         ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
 
     aiqpd = train_analogdownscaling(
-        coarse_reference=ref_coarse, fine_reference=ref_fine, variable=variable, kind=kind_map[kind]
+        coarse_reference=ref_coarse,
+        fine_reference=ref_fine,
+        variable=variable,
+        kind=kind_map[kind],
     )
 
     storage.write(out, aiqpd.ds)
+
 
 @log_service
 def apply_aiqpd(simulation, aiqpd, year, variable, out):
@@ -166,7 +170,7 @@ def apply_aiqpd(simulation, aiqpd, year, variable, out):
         AIQPD-downscaled simulation data will be written.
     """
     sim_ds = storage.read(simulation)
-    qdm_ds = storage.read(aiqpd)
+    aiqpd_ds = storage.read(aiqpd)
 
     year = int(year)
     variable = str(variable)
@@ -181,6 +185,7 @@ def apply_aiqpd(simulation, aiqpd, year, variable, out):
     logger.debug(f"Writing to {out}")
     downscaled_ds.to_netcdf(out, compute=True)
     logger.info(f"Written {out}")
+
 
 @log_service
 def bias_correct(x, x_train, train_variable, y_train, out, out_variable, method):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -54,12 +54,14 @@ def train_qdm(historical, reference, out, variable, kind):
     ref = storage.read(reference)
 
     kind_map = {"additive": "+", "multiplicative": "*"}
-    if kind not in kind_map.keys():
+    try:
+        k = kind_map[kind]
+    except KeyError:
         # So we get a helpful exception message showing accepted kwargs...
-        ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
+        raise ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
 
     qdm = train_quantiledeltamapping(
-        reference=ref, historical=hist, variable=variable, kind=kind_map[kind]
+        reference=ref, historical=hist, variable=variable, kind=k
     )
 
     storage.write(out, qdm.ds)
@@ -81,7 +83,7 @@ def apply_qdm(simulation, qdm, year, variable, out, include_quantiles=False):
     year : int
         Target year to adjust, with rolling years and day grouping.
     variable : str
-        Target variable in `sim` to adjust. Adjusted output will share the
+        Target variable in `simulation` to adjust. Adjusted output will share the
         same name.
     out : str
         fsspec-compatible path or URL pointing to NetCDF4 file where the
@@ -121,7 +123,7 @@ def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
     coarse_reference : str
         fsspec-compatible URL to resampled coarse reference store.
     fine_reference : str
-        fsspec-compatible URL to fine resolution reference store.
+        fsspec-compatible URL to fine-resolution reference store.
     out : str
         fsspec-compatible URL to store adjustment factors.
     variable : str
@@ -163,7 +165,7 @@ def apply_aiqpd(simulation, aiqpd, year, variable, out):
     year : int
         Target year to adjust, with rolling years and day grouping.
     variable : str
-        Target variable in `sim` to downscale. Downscaled output will share the
+        Target variable in `simulation` to downscale. Downscaled output will share the
         same name.
     out : str
         fsspec-compatible path or URL pointing to NetCDF4 file where the

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -185,7 +185,7 @@ def apply_aiqpd(simulation, aiqpd, year, variable, out):
     # currently faster and more reliable than Zarr Stores. This logic is handled
     # in workflow and cloud artifact repository.
     logger.debug(f"Writing to {out}")
-    downscaled_ds.to_netcdf(out, compute=True)
+    downscaled_ds.to_netcdf(out, compute=True, engine="netcdf4")
     logger.info(f"Written {out}")
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -12,6 +12,8 @@ from dodola.core import (
     apply_wet_day_frequency_correction,
     train_quantiledeltamapping,
     adjust_quantiledeltamapping_year,
+    train_analogdownscaling,
+    adjust_analogdownscaling_year,
 )
 import dodola.repository as storage
 
@@ -102,6 +104,76 @@ def apply_qdm(simulation, qdm, year, variable, out):
     adjusted_ds.to_netcdf(out, compute=True)
     logger.info(f"Written {out}")
 
+
+@log_service
+def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
+    """Train analog-inspired quantile preserving downscaling and dump to `out`
+
+    Parameters
+    ----------
+    coarse_reference : str
+        fsspec-compatible URL to resampled coarse reference store.
+    fine_reference : str
+        fsspec-compatible URL to fine resolution reference store.
+    out : str
+        fsspec-compatible URL to store adjustment factors.
+    variable : str
+        Name of target variable in input and output stores.
+    kind : {"additive", "multiplicative"}
+        Kind of AIQPD downscaling.
+    """
+    ref_coarse = storage.read(coarse_reference)
+    ref_fine = storage.read(fine_reference)
+
+    kind_map = {"additive": "+", "multiplicative": "*"}
+    if kind not in kind_map.keys():
+        # So we get a helpful exception message showing accepted kwargs...
+        ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
+
+    aiqpd = train_analogdownscaling(
+        coarse_reference=ref_coarse, fine_reference=ref_fine, variable=variable, kind=kind_map[kind]
+    )
+
+    storage.write(out, aiqpd.ds)
+
+@log_service
+def apply_aiqpd(simulation, aiqpd, year, variable, out):
+    """Apply AIQPD adjustment factors to downscale a year within a simulation, dump to NetCDF.
+
+    Dumping to NetCDF is a feature likely to change in the near future.
+
+    Parameters
+    ----------
+    simulation : str
+        fsspec-compatible URL containing simulation data to be adjusted.
+    aiqpd : str
+        fsspec-compatible URL pointing to Zarr Store containing canned
+        ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling`` Dataset.
+    year : int
+        Target year to adjust, with rolling years and day grouping.
+    variable : str
+        Target variable in `sim` to downscale. Downscaled output will share the
+        same name.
+    out : str
+        fsspec-compatible path or URL pointing to NetCDF4 file where the
+        AIQPD-downscaled simulation data will be written.
+    """
+    sim_ds = storage.read(simulation)
+    qdm_ds = storage.read(aiqpd)
+
+    year = int(year)
+    variable = str(variable)
+
+    downscaled_ds = adjust_analogdownscaling_year(
+        simulation=sim_ds, aiqpd=aiqpd_ds, year=year, variable=variable
+    )
+
+    # Write to NetCDF, usually on local disk, pooling and "fanning-in" NetCDFs is
+    # currently faster and more reliable than Zarr Stores. This logic is handled
+    # in workflow and cloud artifact repository.
+    logger.debug(f"Writing to {out}")
+    downscaled_ds.to_netcdf(out, compute=True)
+    logger.info(f"Written {out}")
 
 @log_service
 def bias_correct(x, x_train, train_variable, y_train, out, out_variable, method):

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -15,6 +15,8 @@ import dodola.services
         "train-qdm",
         "apply-qdm",
         "correct-wetday-frequency",
+        "train-aiqpd",
+        "apply-aiqpd",
     ],
     ids=(
         "--help",
@@ -25,6 +27,8 @@ import dodola.services
         "train-qdm --help",
         "apply-qdm --help",
         "correct-wetday-frequency --help",
+        "train-aiqpd --help",
+        "apply-aiqpd --help",
     ),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -225,7 +225,11 @@ def test_analoginspired_quantilepreserving_downscaling():
 
     # now downscale
     aiqpd = train_analogdownscaling(
-        temp_slice_mean_resampled.to_dataset(name="scen"), temp_slice.to_dataset(name="scen"), variable="scen", kind="+", quantiles_n=62
+        temp_slice_mean_resampled.to_dataset(name="scen"),
+        temp_slice.to_dataset(name="scen"),
+        variable="scen",
+        kind="+",
+        quantiles_n=62,
     )
 
     # make bias corrected data on the fine resolution grid

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -191,10 +191,8 @@ def test_adjust_quantiledeltamapping_year_output_time():
 
 
 def test_analoginspired_quantilepreserving_downscaling():
-    """Tests that analog-inspired quantile-preserving downscaling
-    method produces downscaled values for a fine-res grid such
-    that the average of the downscaled values equals the bias
-    corrected value for that timestep"""
+    """Tests that the average of AIQPD values equals the bias corrected
+    value for the corresponding coarse-res gridcells"""
     # load test data - using xarray's air temperature tutorial dataset
     # resample to daily
     ds = xr.tutorial.load_dataset("air_temperature").resample(time="D").mean()

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -225,7 +225,7 @@ def test_analoginspired_quantilepreserving_downscaling():
 
     # now downscale
     aiqpd = train_analogdownscaling(
-        temp_slice_mean_resampled, temp_slice, quantiles_n=62
+        temp_slice_mean_resampled, temp_slice, variable="scen", kind="+", quantiles_n=62
     )
 
     # make bias corrected data on the fine resolution grid

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -225,7 +225,7 @@ def test_analoginspired_quantilepreserving_downscaling():
 
     # now downscale
     aiqpd = train_analogdownscaling(
-        temp_slice_mean_resampled, temp_slice, nquantiles=62
+        temp_slice_mean_resampled, temp_slice, quantiles_n=62
     )
 
     # make bias corrected data on the fine resolution grid

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -224,8 +224,8 @@ def test_analoginspired_quantilepreserving_downscaling():
         )
 
     # now downscale
-    # note that we are testing with 62 quantiles because we 
-    # only have two years of data 
+    # note that we are testing with 62 quantiles because we
+    # only have two years of data
     aiqpd = train_analogdownscaling(
         temp_slice_mean_resampled.to_dataset(name="scen"),
         temp_slice.to_dataset(name="scen"),

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -242,6 +242,6 @@ def test_analoginspired_quantilepreserving_downscaling():
     bias_corrected_value = biascorrected.isel(time=100).values[0][0]
     downscaled_average = aiqpd_downscaled.isel(time=100).mean().values
 
-    assert assert_approx_equal(
+    assert_approx_equal(
         bias_corrected_value, downscaled_average, significant=5, verbose=True
     )

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -11,7 +11,6 @@ from dodola.core import (
     train_quantiledeltamapping,
     adjust_quantiledeltamapping_year,
     train_analogdownscaling,
-    adjust_analogdownscaling_year,
 )
 
 
@@ -193,11 +192,28 @@ def test_adjust_quantiledeltamapping_year_output_time():
 def test_analoginspired_quantilepreserving_downscaling():
     """Tests that the average of AIQPD values equals the bias corrected
     value for the corresponding coarse-res gridcells"""
-    # load test data - using xarray's air temperature tutorial dataset
-    # resample to daily
-    ds = xr.tutorial.load_dataset("air_temperature").resample(time="D").mean()
+    # make test data 
+    np.random.seed(0)
+    lon = [-99.83, -99.32, -99.79, -99.23]
+    lat = [42.25, 42.21, 42.63, 42.59]
+    # TO-DO: update time range to include +/- 15 days 
+    time = pd.date_range(start='1995-01-01', end='2014-12-31')
+    temperature = 15 + 8 * np.random.randn(len(time), 4, 4)
+
+    ds = xr.Dataset(
+     data_vars=dict(
+         air=(["time", "lat", "lon"], temperature),
+     ),
+     coords=dict(
+         time=time,
+         lon=(["lon"], lon),
+         lat=(["lat"], lat),
+     ),
+     attrs=dict(description="Weather related data."),
+     )    
+
     # remove leap days and only use four gridcells
-    temp_slice = convert_calendar(ds["air"][:, :2, :2], target="noleap")
+    temp_slice = convert_calendar(ds["air"], target="noleap")
 
     # take the mean across space to represent coarse reference data for AFs
     temp_slice_mean = temp_slice.mean(["lat", "lon"])
@@ -229,7 +245,7 @@ def test_analoginspired_quantilepreserving_downscaling():
         temp_slice.to_dataset(name="scen"),
         variable="scen",
         kind="+",
-        quantiles_n=62,
+        quantiles_n=620,
     )
 
     # make bias corrected data on the fine resolution grid

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import assert_approx_equal
 import pytest
+import pandas as pd
 import xarray as xr
 import cftime
 from xclim.core.calendar import convert_calendar
@@ -192,25 +193,25 @@ def test_adjust_quantiledeltamapping_year_output_time():
 def test_analoginspired_quantilepreserving_downscaling():
     """Tests that the average of AIQPD values equals the bias corrected
     value for the corresponding coarse-res gridcells"""
-    # make test data 
+    # make test data
     np.random.seed(0)
     lon = [-99.83, -99.32, -99.79, -99.23]
     lat = [42.25, 42.21, 42.63, 42.59]
-    # TO-DO: update time range to include +/- 15 days 
-    time = pd.date_range(start='1995-01-01', end='2014-12-31')
+    # TO-DO: update time range to include +/- 15 days
+    time = pd.date_range(start="1995-01-01", end="2014-12-31")
     temperature = 15 + 8 * np.random.randn(len(time), 4, 4)
 
     ds = xr.Dataset(
-     data_vars=dict(
-         air=(["time", "lat", "lon"], temperature),
-     ),
-     coords=dict(
-         time=time,
-         lon=(["lon"], lon),
-         lat=(["lat"], lat),
-     ),
-     attrs=dict(description="Weather related data."),
-     )    
+        data_vars=dict(
+            air=(["time", "lat", "lon"], temperature),
+        ),
+        coords=dict(
+            time=time,
+            lon=(["lon"], lon),
+            lat=(["lat"], lat),
+        ),
+        attrs=dict(description="Weather related data."),
+    )
 
     # remove leap days and only use four gridcells
     temp_slice = convert_calendar(ds["air"], target="noleap")

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -224,6 +224,8 @@ def test_analoginspired_quantilepreserving_downscaling():
         )
 
     # now downscale
+    # note that we are testing with 62 quantiles because we 
+    # only have two years of data 
     aiqpd = train_analogdownscaling(
         temp_slice_mean_resampled.to_dataset(name="scen"),
         temp_slice.to_dataset(name="scen"),

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -225,7 +225,7 @@ def test_analoginspired_quantilepreserving_downscaling():
 
     # now downscale
     aiqpd = train_analogdownscaling(
-        temp_slice_mean_resampled, temp_slice, variable="scen", kind="+", quantiles_n=62
+        temp_slice_mean_resampled.to_dataset(name="scen"), temp_slice.to_dataset(name="scen"), variable="scen", kind="+", quantiles_n=62
     )
 
     # make bias corrected data on the fine resolution grid

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -613,9 +613,9 @@ def test_analoginspired_quantilepreserving_downscaling():
     bc_url = "memory://test_aiqpd_downscaling/a/bias_corrected/path.zarr"
     train_out_url = "memory://test_aiqpd_downscaling/a/train_output/path.zarr"
     adjust_out_url = "memory://test_aiqpd_downscaling/a/adjust_output/path.zarr"
-    repository.write(ref_coarse_url, temp_slice_mean_resampled.to_dataset(name="scen"))
-    repository.write(ref_fine_url, temp_slice.to_dataset(name="scen"))
-    repository.write(bc_url, biascorrected.to_dataset(name="scen"))
+    repository.write(ref_coarse_url, temp_slice_mean_resampled.to_dataset(name="scen").chunk({'time': -1}))
+    repository.write(ref_fine_url, temp_slice.to_dataset(name="scen").chunk({'time': -1}))
+    repository.write(bc_url, biascorrected.to_dataset(name="scen").chunk({'time': -1}))
 
     # now downscale
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -615,7 +615,7 @@ def test_analoginspired_quantilepreserving_downscaling():
     adjust_out_url = "memory://test_aiqpd_downscaling/a/adjust_output/path.zarr"
     repository.write(ref_coarse_url, temp_slice_mean_resampled.to_dataset(name="scen"))
     repository.write(ref_fine_url, temp_slice.to_dataset(name="scen"))
-    repository.write(bc_url, biascorrected)
+    repository.write(bc_url, biascorrected.to_dataset(name="scen"))
 
     # now downscale
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "+")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -613,9 +613,14 @@ def test_analoginspired_quantilepreserving_downscaling():
     bc_url = "memory://test_aiqpd_downscaling/a/bias_corrected/path.zarr"
     train_out_url = "memory://test_aiqpd_downscaling/a/train_output/path.zarr"
     adjust_out_url = "memory://test_aiqpd_downscaling/a/adjust_output/path.zarr"
-    repository.write(ref_coarse_url, temp_slice_mean_resampled.to_dataset(name="scen").chunk({'time': -1}))
-    repository.write(ref_fine_url, temp_slice.to_dataset(name="scen").chunk({'time': -1}))
-    repository.write(bc_url, biascorrected.to_dataset(name="scen").chunk({'time': -1}))
+    repository.write(
+        ref_coarse_url,
+        temp_slice_mean_resampled.to_dataset(name="scen").chunk({"time": -1}),
+    )
+    repository.write(
+        ref_fine_url, temp_slice.to_dataset(name="scen").chunk({"time": -1})
+    )
+    repository.write(bc_url, biascorrected.to_dataset(name="scen").chunk({"time": -1}))
 
     # now downscale
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -566,8 +566,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
     np.random.seed(0)
     lon = [-99.83, -99.32, -99.79, -99.23]
     lat = [42.25, 42.21, 42.63, 42.59]
-    # TO-DO: update time range to include +/- 15 days
-    time = pd.date_range(start="1995-01-01", end="2014-12-31")
+    time = pd.date_range(start="1994-12-17", end="2015-01-15")
     temperature = 15 + 8 * np.random.randn(len(time), 4, 4)
 
     ds = xr.Dataset(

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -626,7 +626,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
     biascorrected = biascorrected.to_dataset(name="scen")
     repository.write(bc_url, biascorrected)
 
-    # now downscale
+    # now train AIQPD model
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")
 
     # load adjustment factors
@@ -634,7 +634,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
 
     af_expected_shape = (len(lon), len(lat), 365, 620)
 
-    assert aiqpd_model.ds.af.shape == af_expected_shape
+    assert aiqpd_model.af.shape == af_expected_shape
 
 
 @pytest.mark.parametrize(

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -618,7 +618,7 @@ def test_analoginspired_quantilepreserving_downscaling():
     repository.write(bc_url, biascorrected.to_dataset(name="scen"))
 
     # now downscale
-    train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "+")
+    train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")
 
     # downscale the bias corrected data
     apply_aiqpd(bc_url, train_out_url, 2000, "scen", adjust_out_url)

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -557,9 +557,12 @@ def test_correct_wet_day_frequency(process):
         )
 
 
-def test_analoginspired_quantilepreserving_downscaling(tmpdir):
+def test_analoginspired_quantilepreserving_downscaling(tmpdir, monkeypatch):
     """Tests that the average of AIQPD values equals the bias corrected
     value for the corresponding coarse-res gridcells"""
+    monkeypatch.setenv(
+        "HDF5_USE_FILE_LOCKING", "FALSE"
+    )  # Avoid thread lock conflicts with dask scheduler
     # make test data
     np.random.seed(0)
     lon = [-99.83, -99.32, -99.79, -99.23]
@@ -623,7 +626,9 @@ def test_analoginspired_quantilepreserving_downscaling(tmpdir):
     repository.write(
         ref_fine_url, temp_slice.to_dataset(name="scen").chunk({"time": -1})
     )
-    repository.write(bc_url, biascorrected.to_dataset(name="scen"))
+    # repository.write(bc_url, biascorrected.to_dataset(name="scen"))
+    biascorrected = biascorrected.to_dataset(name="scen")
+    repository.write(bc_url, biascorrected)
 
     # now downscale
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -623,7 +623,7 @@ def test_analoginspired_quantilepreserving_downscaling(tmpdir):
     repository.write(
         ref_fine_url, temp_slice.to_dataset(name="scen").chunk({"time": -1})
     )
-    repository.write(bc_url, biascorrected.to_dataset(name="scen").chunk({"time": -1}))
+    repository.write(bc_url, biascorrected.to_dataset(name="scen"))
 
     # now downscale
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")

--- a/environment.yaml
+++ b/environment.yaml
@@ -21,4 +21,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/Ouranosinc/xclim@d1e654cf59a5d5761f5586bca1102a1590ae6e32
+  - git+https://github.com/ClimateImpactLab/xclim@add_analog_downscaling

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,6 +8,7 @@ dependencies:
 - cftime=1.5.0
 - fsspec=2021.5.0  # Prevent azure blob errors, not hard req.
 - gcsfs=2021.5.0
+- netcdf4
 - numpy=1.20.3
 - pandas=1.2.5  # Not direct dependency, workaround to time slice bug in #96
 - pip=21.1.2

--- a/environment.yaml
+++ b/environment.yaml
@@ -21,5 +21,6 @@ dependencies:
 - bottleneck=1.3.2
 - zarr=2.8.3
 - pip:
+  - pooch 
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
   - git+https://github.com/ClimateImpactLab/xclim@add_analog_downscaling

--- a/environment.yaml
+++ b/environment.yaml
@@ -19,6 +19,5 @@ dependencies:
 - bottleneck=1.3.2
 - zarr=2.8.3
 - pip:
-  - pooch 
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
   - git+https://github.com/ClimateImpactLab/xclim@add_analog_downscaling


### PR DESCRIPTION
This PR adds the analog-inspired, quantile-preserving downscaling method as a new service. It is split up into two services, `train_aiqpd` and `adjust_aiqpd` and is based on the implementation of QDM. This is intended to supersede spatial disaggregation as the main mode of downscaling in `dodola` for the time being. 

Basic CLI interface is: 

```
dodola train_aiqpd /path/to/coarse_reference.zarr \
/path/to/fine_reference.zarr 
--out /path/to/trained_afs.zarr \
--v "tasmax", 
--k "+"
```

```
dodola apply_aiqpd /path/to/biascorrected.zarr \
/path/to/trainedafs/zarr \
-- year 2026
 --v "tasmax" 
--out /path/to/trained_afs.zarr \
```

closes #73 

