### PR TITLE
Pin xclim version in environment

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -18,8 +18,8 @@ dependencies:
 - s3fs=2021.5.0
 - xarray=0.18.2
 - xesmf=0.5.3
-- xclim=0.27.0
 - bottleneck=1.3.2
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
+  - xclim==0.27.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -22,4 +22,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - xclim 
+  - xclim==0.27.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -18,8 +18,8 @@ dependencies:
 - s3fs=2021.5.0
 - xarray=0.18.2
 - xesmf=0.5.3
+- xclim=0.27.0
 - bottleneck=1.3.2
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - xclim==0.27.0


### PR DESCRIPTION
Pinning a loose `xclim` package version in prep for the next release.

Related to #97.