### PR TITLE
Drop explicit distributed, dask-kubernetes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,6 @@ History
 * Add precipitation unit conversion to ``standardize_gcm``. (PR #94, @dgergel)
 * Add ``astype`` argument to ``regrid``. (PR #92, @brews)
 * Make ``dodola`` container's default CMD. (PR #90, @brews)
-* Add ``dask-kubernetes``, ``distributed`` to container environment. (PR #90, @brews)
 * Improve subprocess and death handling in Docker container. (PR #90, @brews)
 * Fix bug in train_quantiledeltamapping accounting for endpoints. (#87, @brews)
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,8 +4,6 @@ channels:
 dependencies:
 - adlfs=0.7.5  # Prevent azure blob errors, not hard req.
 - dask=2021.6.0
-- distributed=2021.6.0  # Not direct dodola dependency. Used in prototypes.
-- dask-kubernetes=2021.3.1  # Not direct dodola dependency. Used in prototypes.
 - click=8.0.1
 - cftime=1.5.0
 - fsspec=2021.5.0  # Prevent azure blob errors, not hard req.


### PR DESCRIPTION
These dependencies are not directly required or used outside of dev. Removing in prep for release.

Can put the packages in after the next release if we want them for dev and future features. This is just cleaning up non-essential cruft.