### PR TITLE
Bump xclim to v0.28.0, improve environment notes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 0.X.X (XXXX-XX-XX)
 ------------------
 * Fix application logging to stdout. (PR #104, @brews)
-* Bump environment `xclim` to v0.28.0. (PR #105, @brews)
+* Bump xclim to v0.28.0, improve environment notes. (PR #105, @brews)
 
 
 0.4.0 (2021-07-09)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* 
+* Bump environment `xclim` to v0.28.0. (PR #105, @brews)
 
 
 0.4.0 (2021-07-09)

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,7 +9,7 @@ dependencies:
 - fsspec=2021.5.0  # Prevent azure blob errors, not hard req.
 - gcsfs=2021.5.0
 - numpy=1.20.3
-- pandas=1.2.5
+- pandas=1.2.5  # Not direct dependency, workaround to time slice bug in #96
 - pip=21.1.2
 - pytest=6.2.4
 - python=3.9

--- a/environment.yaml
+++ b/environment.yaml
@@ -20,4 +20,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - xclim==0.27.0
+  - xclim==0.28.0


### PR DESCRIPTION
Minor version upgrade to `xclim`.

Also notes reason for `pandas` pin. Close #97.