### PR TITLE
Add papermill, intake-esm to docker environment

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.x.x (xxxx-xx-xx)
 ------------------
-* Add ``intake-esm`` to Docker environment (PR #106, @brews).
+* Add ``papermill``, ``intake-esm`` to Docker environment. (PR #106, @brews)
 
 
 0.4.1 (2021-07-13)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.x.x (xxxx-xx-xx)
 ------------------
-* 
+* Add ``intake-esm`` to Docker environment (PR #106, @brews).
 
 
 0.4.1 (2021-07-13)

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,6 +6,8 @@ dependencies:
 - dask=2021.6.0
 - click=8.0.1
 - cftime=1.5.0
+- intake=0.6.2  # Not direct dependency. Used in docker environment.
+- intake-esm=2021.1.15  # Not direct dependency. Used in docker environment.
 - fsspec=2021.5.0  # Prevent azure blob errors, not hard req.
 - gcsfs=2021.5.0
 - numpy=1.20.3

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,6 +12,7 @@ dependencies:
 - gcsfs=2021.5.0
 - numpy=1.20.3
 - pandas=1.2.5  # Not direct dependency, workaround to time slice bug in #96
+- papermill=2.3.3  # Not direct dependency. Used in docker environment.
 - pip=21.1.2
 - pytest=6.2.4
 - python=3.9


### PR DESCRIPTION
`intake-esm` is used in docker container scripts for raw CMIP6 download. `papermill` is used to automate notebook runs.

These additions do not relate to the `dodola` application. Beware. They may be removed before the next release.