### PR TITLE
Add --cyclic option to regrid cli and services

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.x.x (xxxx-xx-xx)
 ------------------
+* Add ``--cyclic`` option to regrid cli and services. (PR #108, @brews)
 * Add ``papermill``, ``intake-esm`` to Docker environment. (PR #106, @brews)
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -233,7 +233,9 @@ def rechunk(x, chunk, out):
     help="Local path to existing regrid weights file",
 )
 @click.option("--astype", "-t", default=None, help="Type to recast output to")
-@click.option("--cyclic", default=None, help="Add wrap-around values to dim before regridding")
+@click.option(
+    "--cyclic", default=None, help="Add wrap-around values to dim before regridding"
+)
 def regrid(x, out, method, domain_file, weightspath, astype, addcyclic):
     """Regrid a target climate dataset
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -236,7 +236,7 @@ def rechunk(x, chunk, out):
 @click.option(
     "--cyclic", default=None, help="Add wrap-around values to dim before regridding"
 )
-def regrid(x, out, method, domain_file, weightspath, astype, addcyclic):
+def regrid(x, out, method, domain_file, weightspath, astype, cyclic):
     """Regrid a target climate dataset
 
     Note, the weightspath only accepts paths to NetCDF files on the local disk. See
@@ -251,7 +251,7 @@ def regrid(x, out, method, domain_file, weightspath, astype, addcyclic):
         domain_file=domain_file,
         weights_path=weightspath,
         astype=astype,
-        add_cyclic=addcyclic,
+        add_cyclic=cyclic,
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -233,7 +233,8 @@ def rechunk(x, chunk, out):
     help="Local path to existing regrid weights file",
 )
 @click.option("--astype", "-t", default=None, help="Type to recast output to")
-def regrid(x, out, method, domain_file, weightspath, astype):
+@click.option("--cyclic", default=None, help="Add wrap-around values to dim before regridding")
+def regrid(x, out, method, domain_file, weightspath, astype, addcyclic):
     """Regrid a target climate dataset
 
     Note, the weightspath only accepts paths to NetCDF files on the local disk. See
@@ -248,6 +249,7 @@ def regrid(x, out, method, domain_file, weightspath, astype):
         domain_file=domain_file,
         weights_path=weightspath,
         astype=astype,
+        add_cyclic=addcyclic,
     )
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -262,7 +262,9 @@ def rechunk(x, target_chunks, out):
 
 
 @log_service
-def regrid(x, out, method, domain_file, weights_path=None, astype=None, add_cyclic=None):
+def regrid(
+    x, out, method, domain_file, weights_path=None, astype=None, add_cyclic=None
+):
     """Regrid climate data
 
     Parameters

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -262,7 +262,7 @@ def rechunk(x, target_chunks, out):
 
 
 @log_service
-def regrid(x, out, method, domain_file, weights_path=None, astype=None):
+def regrid(x, out, method, domain_file, weights_path=None, astype=None, add_cyclic=None):
     """Regrid climate data
 
     Parameters
@@ -279,9 +279,12 @@ def regrid(x, out, method, domain_file, weights_path=None, astype=None):
         Local file path name to write regridding weights file to.
     astype : str, numpy.dtype, or None, optional
         Typecode or data-type to which the regridded output is cast.
+    add_cyclic : str, or None, optional
+        Add cyclic (aka wrap-around values) to dimension before regridding.
+         Useful for avoiding dateline artifacts along longitude in global
+         datasets.
     """
     ds = storage.read(x)
-
     ds_domain = storage.read(domain_file)
 
     regridded_ds = xesmf_regrid(
@@ -290,6 +293,7 @@ def regrid(x, out, method, domain_file, weights_path=None, astype=None):
         method=method,
         weights_path=weights_path,
         astype=astype,
+        add_cyclic=add_cyclic,
     )
 
     storage.write(out, regridded_ds)

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -5,6 +5,7 @@ import cftime
 from dodola.core import (
     train_quantiledeltamapping,
     adjust_quantiledeltamapping_year,
+    _add_cyclic
 )
 
 
@@ -181,3 +182,14 @@ def test_adjust_quantiledeltamapping_year_output_time():
     assert max(adjusted_ds["time"].values) == cftime.DatetimeNoLeap(
         2088, 12, 31, 0, 0, 0, 0
     )
+
+
+def test_add_cyclic():
+    """Test _add_cyclic adds wraparound values"""
+    in_da = xr.DataArray(
+        np.ones([5, 6]) * np.arange(6),
+        coords=[np.arange(5) + 1, np.arange(6) + 1],
+        dims=["lat", "lon"],
+    )
+    out_ds = _add_cyclic(ds=in_da.to_dataset(name="fakevariable"), dim="lon")
+    assert all(out_ds["fakevariable"].isel(lon=0) == out_ds["fakevariable"].isel(lon=-1))

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -5,7 +5,7 @@ import cftime
 from dodola.core import (
     train_quantiledeltamapping,
     adjust_quantiledeltamapping_year,
-    _add_cyclic
+    _add_cyclic,
 )
 
 
@@ -192,4 +192,6 @@ def test_add_cyclic():
         dims=["lat", "lon"],
     )
     out_ds = _add_cyclic(ds=in_da.to_dataset(name="fakevariable"), dim="lon")
-    assert all(out_ds["fakevariable"].isel(lon=0) == out_ds["fakevariable"].isel(lon=-1))
+    assert all(
+        out_ds["fakevariable"].isel(lon=0) == out_ds["fakevariable"].isel(lon=-1)
+    )


### PR DESCRIPTION
Can now call

```bash
dodola regrid ... --cyclic "lon"
```
to add cyclic points (aka wrap-around pixels) to the "lon" dimension before regridding.

This is the `add_cyclic` option for `dodola.services.regrid`.

Close #107.