### PR TITLE
Bump container environment to xarray to v0.19.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ History
 ------------------
 * Add ``--cyclic`` option to regrid cli and services. (PR #108, @brews)
 * Add ``papermill``, ``intake-esm`` to Docker environment. (PR #106, @brews)
-* Bump environment `xarray` to v0.19.0. (PR #109, @brews)
+* Bump environment ``xarray`` to v0.19.0. (PR #109, @brews)
 
 
 0.4.1 (2021-07-13)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 ------------------
 * Add ``--cyclic`` option to regrid cli and services. (PR #108, @brews)
 * Add ``papermill``, ``intake-esm`` to Docker environment. (PR #106, @brews)
+* Bump environment `xarray` to v0.19.0. (PR #109, @brews)
 
 
 0.4.1 (2021-07-13)

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,7 +17,7 @@ dependencies:
 - pytest=6.2.4
 - python=3.9
 - s3fs=2021.5.0
-- xarray=0.18.2
+- xarray=0.19.0
 - xesmf=0.5.3
 - bottleneck=1.3.2
 - zarr=2.8.3


### PR DESCRIPTION
Jumping this gap is better done sooner rather than later because it makes `consolidate=True` the default with Zarr I/O.