### PR TITLE
AIQPD to operate on full timeseries, add aiqpd_adjust test

### DIFF
--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -112,7 +112,7 @@ def train_qdm(historical, reference, out, variable, kind):
     help="URL to write NetCDF4 with adjusted (downscaled) simulation year to",
 )
 def apply_aiqpd(simulation, aiqpd, variable, out):
-    """Adjust simulation year with AIQPD downscaling method, outputting to local NetCDF4 file"""
+    """Adjust simulation with AIQPD downscaling method, outputting to local NetCDF4 file"""
     services.apply_aiqpd(simulation=simulation, aiqpd=aiqpd, variable=variable, out=out)
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -104,7 +104,6 @@ def train_qdm(historical, reference, out, variable, kind):
     required=True,
     help="URL to trained AIQPD store of adjustment factors",
 )
-@click.option("--year", "-y", required=True, help="Year of simulation to adjust")
 @click.option("--variable", "-v", required=True, help="Variable name in data stores")
 @click.option(
     "--out",
@@ -112,10 +111,10 @@ def train_qdm(historical, reference, out, variable, kind):
     required=True,
     help="URL to write NetCDF4 with adjusted (downscaled) simulation year to",
 )
-def apply_aiqpd(simulation, aiqpd, year, variable, out):
+def apply_aiqpd(simulation, aiqpd, variable, out):
     """Adjust simulation year with AIQPD downscaling method, outputting to local NetCDF4 file"""
     services.apply_aiqpd(
-        simulation=simulation, aiqpd=aiqpd, year=year, variable=variable, out=out
+        simulation=simulation, aiqpd=aiqpd, variable=variable, out=out
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -113,9 +113,7 @@ def train_qdm(historical, reference, out, variable, kind):
 )
 def apply_aiqpd(simulation, aiqpd, variable, out):
     """Adjust simulation year with AIQPD downscaling method, outputting to local NetCDF4 file"""
-    services.apply_aiqpd(
-        simulation=simulation, aiqpd=aiqpd, variable=variable, out=out
-    )
+    services.apply_aiqpd(simulation=simulation, aiqpd=aiqpd, variable=variable, out=out)
 
 
 @dodola_cli.command(

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -162,8 +162,8 @@ def train_analogdownscaling(
     return aiqpd
 
 
-def adjust_analogdownscaling_year(simulation, aiqpd, variable):
-    """Apply AIQPD to downscale a year of bias corrected output.
+def adjust_analogdownscaling(simulation, aiqpd, variable):
+    """Apply AIQPD to downscale bias corrected output.
 
     Parameters
     ----------

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -188,6 +188,9 @@ def adjust_analogdownscaling_year(simulation, aiqpd, variable):
     if isinstance(aiqpd, xr.Dataset):
         aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.from_dataset(aiqpd)
 
+    print("aiqpd AFs are {}".format(aiqpd.ds.af.shape))
+    print("simulation shape is {}".format(simulation[variable].shape))
+
     out = aiqpd.adjust(simulation[variable])
 
     return out.to_dataset(name=variable)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -188,6 +188,8 @@ def adjust_analogdownscaling_year(simulation, aiqpd, variable):
     if isinstance(aiqpd, xr.Dataset):
         aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.from_dataset(aiqpd)
 
+    # aiqpd.ds = aiqpd.ds.chunk({"dayofyear": -1, "lat": -1, "lon": -1})
+
     out = aiqpd.adjust(simulation[variable])
 
     return out.to_dataset(name=variable)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -162,7 +162,7 @@ def train_analogdownscaling(
     return aiqpd
 
 
-def adjust_analogdownscaling_year(simulation, aiqpd, year, variable):
+def adjust_analogdownscaling_year(simulation, aiqpd, variable):
     """Apply AIQPD to downscale a year of bias corrected output.
 
     Parameters
@@ -173,8 +173,6 @@ def adjust_analogdownscaling_year(simulation, aiqpd, year, variable):
         Trained ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling``, or
         Dataset representation that will instantiate
         ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling``.
-    year : int
-        Target year to downscale, with day grouping.
     variable : str
         Target variable in `simulation` to downscale. Downscaled output will share the
         same name.
@@ -185,17 +183,12 @@ def adjust_analogdownscaling_year(simulation, aiqpd, year, variable):
         AIQPD-downscaled values from `simulation`. May be a lazy-evaluated future, not
         yet computed.
     """
-    year = int(year)
     variable = str(variable)
 
     if isinstance(aiqpd, xr.Dataset):
         aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.from_dataset(aiqpd)
 
-    # Slice to get 15 days before and after our target year. This accounts
-    # for the rolling 31 day rolling window.
-    timeslice = slice(f"{year}-01-01", f"{year}-12-31")
-    simulation = simulation[variable].sel(time=timeslice)
-    out = aiqpd.adjust(simulation)
+    out = aiqpd.adjust(simulation[variable])
 
     return out.to_dataset(name=variable)
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -188,8 +188,6 @@ def adjust_analogdownscaling_year(simulation, aiqpd, variable):
     if isinstance(aiqpd, xr.Dataset):
         aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.from_dataset(aiqpd)
 
-    # aiqpd.ds = aiqpd.ds.chunk({"dayofyear": -1, "lat": -1, "lon": -1})
-
     out = aiqpd.adjust(simulation[variable])
 
     return out.to_dataset(name=variable)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -188,9 +188,6 @@ def adjust_analogdownscaling_year(simulation, aiqpd, variable):
     if isinstance(aiqpd, xr.Dataset):
         aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.from_dataset(aiqpd)
 
-    print("aiqpd AFs are {}".format(aiqpd.ds.af.shape))
-    print("simulation shape is {}".format(simulation[variable].shape))
-
     out = aiqpd.adjust(simulation[variable])
 
     return out.to_dataset(name=variable)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -176,7 +176,7 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
 
     # zarr dimensions can be garbled, and if dim order
     # is not lat, lon, dayofyear, quantile, cannot broadcast
-    aiqpd_ds = aiqpd_ds.transpose("lon", "lat", "dayofyear", "quantiles")
+    # aiqpd_ds = aiqpd_ds.transpose("lon", "lat", "dayofyear", "quantiles")
 
     # also needs to not be chunked
     sim_ds = sim_ds.load()

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -174,6 +174,14 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
     sim_ds = storage.read(simulation)
     aiqpd_ds = storage.read(aiqpd)
 
+    # zarr dimensions can be garbled, and if dim order
+    # is not lat, lon, dayofyear, quantile, cannot broadcast
+    aiqpd_ds = aiqpd_ds.transpose("lon", "lat", "dayofyear", "quantiles")
+
+    # also needs to not be chunked
+    sim_ds = sim_ds.chunk({"time": -1, "lat": -1, "lon": -1})
+    aiqpd_ds = aiqpd_ds.chunk({"dayofyear": -1, "lat": -1, "lon": -1})
+
     variable = str(variable)
 
     downscaled_ds = adjust_analogdownscaling_year(

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -153,7 +153,7 @@ def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
 
 @log_service
 def apply_aiqpd(simulation, aiqpd, variable, out):
-    """Apply AIQPD adjustment factors to downscale a year within a simulation, dump to NetCDF.
+    """Apply AIQPD adjustment factors to downscale a simulation, dump to NetCDF.
 
     Dumping to NetCDF is a feature likely to change in the near future.
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -174,11 +174,7 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
     sim_ds = storage.read(simulation)
     aiqpd_ds = storage.read(aiqpd)
 
-    # zarr dimensions can be garbled, and if dim order
-    # is not lat, lon, dayofyear, quantile, cannot broadcast
-    # aiqpd_ds = aiqpd_ds.transpose("lon", "lat", "dayofyear", "quantiles")
-
-    # also needs to not be chunked
+    # needs to not be chunked
     sim_ds = sim_ds.load()
     aiqpd_ds = aiqpd_ds.load()
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -176,13 +176,11 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
 
     # zarr dimensions can be garbled, and if dim order
     # is not lat, lon, dayofyear, quantile, cannot broadcast
-    # aiqpd_ds = aiqpd_ds.transpose("lon", "lat", "dayofyear", "quantiles")
+    aiqpd_ds = aiqpd_ds.transpose("lon", "lat", "dayofyear", "quantiles")
 
     # also needs to not be chunked
-    # sim_ds = sim_ds.chunk({"time": -1, "lat": -1, "lon": -1})
     sim_ds = sim_ds.load()
     aiqpd_ds = aiqpd_ds.load()
-    # aiqpd_ds = aiqpd_ds.chunk({"dayofyear": -1, "lat": -1, "lon": -1})
 
     variable = str(variable)
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -152,7 +152,7 @@ def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
 
 
 @log_service
-def apply_aiqpd(simulation, aiqpd, year, variable, out):
+def apply_aiqpd(simulation, aiqpd, variable, out):
     """Apply AIQPD adjustment factors to downscale a year within a simulation, dump to NetCDF.
 
     Dumping to NetCDF is a feature likely to change in the near future.
@@ -164,8 +164,6 @@ def apply_aiqpd(simulation, aiqpd, year, variable, out):
     aiqpd : str
         fsspec-compatible URL pointing to Zarr Store containing canned
         ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling`` Dataset.
-    year : int
-        Target year to adjust, with rolling years and day grouping.
     variable : str
         Target variable in `simulation` to downscale. Downscaled output will share the
         same name.
@@ -176,11 +174,10 @@ def apply_aiqpd(simulation, aiqpd, year, variable, out):
     sim_ds = storage.read(simulation)
     aiqpd_ds = storage.read(aiqpd)
 
-    year = int(year)
     variable = str(variable)
 
     downscaled_ds = adjust_analogdownscaling_year(
-        simulation=sim_ds, aiqpd=aiqpd_ds, year=year, variable=variable
+        simulation=sim_ds, aiqpd=aiqpd_ds, variable=variable
     )
 
     # Write to NetCDF, usually on local disk, pooling and "fanning-in" NetCDFs is

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -13,7 +13,7 @@ from dodola.core import (
     train_quantiledeltamapping,
     adjust_quantiledeltamapping_year,
     train_analogdownscaling,
-    adjust_analogdownscaling_year,
+    adjust_analogdownscaling,
 )
 import dodola.repository as storage
 
@@ -184,7 +184,7 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
 
     variable = str(variable)
 
-    downscaled_ds = adjust_analogdownscaling_year(
+    downscaled_ds = adjust_analogdownscaling(
         simulation=sim_ds, aiqpd=aiqpd_ds, variable=variable
     )
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -176,11 +176,13 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
 
     # zarr dimensions can be garbled, and if dim order
     # is not lat, lon, dayofyear, quantile, cannot broadcast
-    aiqpd_ds = aiqpd_ds.transpose("lon", "lat", "dayofyear", "quantiles")
+    # aiqpd_ds = aiqpd_ds.transpose("lon", "lat", "dayofyear", "quantiles")
 
     # also needs to not be chunked
-    sim_ds = sim_ds.chunk({"time": -1, "lat": -1, "lon": -1})
-    aiqpd_ds = aiqpd_ds.chunk({"dayofyear": -1, "lat": -1, "lon": -1})
+    # sim_ds = sim_ds.chunk({"time": -1, "lat": -1, "lon": -1})
+    sim_ds = sim_ds.load()
+    aiqpd_ds = aiqpd_ds.load()
+    # aiqpd_ds = aiqpd_ds.chunk({"dayofyear": -1, "lat": -1, "lon": -1})
 
     variable = str(variable)
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -2,13 +2,10 @@
 """
 
 import numpy as np
-from numpy.testing import assert_approx_equal
 import pytest
 import xarray as xr
 from xesmf.data import wave_smooth
 from xesmf.util import grid_global
-from xclim.sdba.utils import equally_spaced_nodes
-from xclim import sdba, set_options
 from xclim.sdba.adjustment import QuantileDeltaMapping
 from dodola.services import (
     bias_correct,
@@ -581,7 +578,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
-    # tile the fine resolution grid with the coarse resolution ref data 
+    # tile the fine resolution grid with the coarse resolution ref data
     ref_coarse = ds_ref_coarse.broadcast_like(ref_fine)
 
     # write test data
@@ -607,7 +604,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
 
 
 def test_aiqpd_integration(tmpdir, monkeypatch):
-    """Tests that the shape of adjustment factors matches the expected shape"""
+    """Integration test of the QDM and AIQPD services"""
     monkeypatch.setenv(
         "HDF5_USE_FILE_LOCKING", "FALSE"
     )  # Avoid thread lock conflicts with dask scheduler
@@ -645,7 +642,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
     ds_train = ds_train.mean(["lat", "lon"])
-    # tile the fine resolution grid with the coarse resolution ref data 
+    # tile the fine resolution grid with the coarse resolution ref data
     ref_coarse = ds_ref_coarse.broadcast_like(ref_fine)
     ds_bc = ds_train + 3
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -592,7 +592,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
         ref_coarse_url,
         ref_coarse.chunk({"time": -1}),
     )
-    repository.write(ref_fine_url, ref_fine.to_dataset(name="scen").chunk({"time": -1}))
+    repository.write(ref_fine_url, ref_fine.chunk({"time": -1}))
 
     # now train AIQPD model
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")
@@ -660,17 +660,17 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # write bias corrected data differently because it's a NetCDF, not a zarr
     sim_biascorrected_key = tmpdir.join("sim_biascorrected.nc")
 
-    repository.write(ref_coarse_coarse_url, ds_ref_coarse.to_dataset(name=variable))
+    repository.write(ref_coarse_coarse_url, ds_ref_coarse)
     repository.write(
         ref_coarse_url,
-        ref_coarse.to_dataset(name=variable).chunk({"time": -1, "lat": -1, "lon": -1}),
+        ref_coarse.chunk({"time": -1, "lat": -1, "lon": -1}),
     )
     repository.write(
         ref_fine_url,
-        ref_fine.to_dataset(name=variable).chunk({"time": -1, "lat": -1, "lon": -1}),
+        ref_fine.chunk({"time": -1, "lat": -1, "lon": -1}),
     )
-    repository.write(qdm_train_url, ds_train.to_dataset(name=variable))
-    repository.write(sim_url, ds_bc.to_dataset(name=variable))
+    repository.write(qdm_train_url, ds_train)
+    repository.write(sim_url, ds_bc)
 
     # this is an integration test between QDM and AIQPD, so use QDM services
     # for bias correction

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -581,6 +581,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
+    # tile the fine resolution grid with the coarse resolution ref data 
     ref_coarse = ds_ref_coarse.broadcast_like(ref_fine)
 
     # write test data
@@ -644,6 +645,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
     ds_train = ds_train.mean(["lat", "lon"])
+    # tile the fine resolution grid with the coarse resolution ref data 
     ref_coarse = ds_ref_coarse.broadcast_like(ref_fine)
     ds_bc = ds_train + 3
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -690,10 +690,14 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # Writes NC to local disk, so diff format here:
     sim_downscaled_key = tmpdir.join("sim_downscaled.nc")
 
-    repository.write(ref_coarse_url, ref_coarse.to_dataset(name="scen"))
-    repository.write(ref_fine_url, ref_fine.to_dataset(name="scen"))
+    repository.write(
+        ref_coarse_url, ref_coarse.to_dataset(name="scen").chunk({"time": -1})
+    )
+    repository.write(ref_fine_url, ref_fine.to_dataset(name="scen").chunk({"time": -1}))
 
-    repository.write(bc_url, biascorrected_year.to_dataset(name="scen"))
+    repository.write(
+        bc_url, biascorrected_year.to_dataset(name="scen").chunk({"time": -1})
+    )
 
     # now train AIQPD model
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -696,7 +696,9 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     )
     repository.write(ref_fine_url, ref_fine.to_dataset(name="scen").chunk({"time": -1}))
 
-    repository.write(bc_url, biascorrected_year.to_dataset(name="scen").chunk({"time": -1}))
+    repository.write(
+        bc_url, biascorrected_year.to_dataset(name="scen").chunk({"time": -1})
+    )
 
     # now train AIQPD model
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -696,8 +696,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     )
     repository.write(ref_fine_url, ref_fine.to_dataset(name="scen").chunk({"time": -1}))
 
-    biascorrected = biascorrected_year.to_dataset(name="scen")
-    repository.write(bc_url, biascorrected)
+    repository.write(bc_url, biascorrected_year.to_dataset(name="scen").chunk({"time": -1}))
 
     # now train AIQPD model
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -5,13 +5,11 @@ import numpy as np
 from numpy.testing import assert_approx_equal
 import pytest
 import xarray as xr
-import pandas as pd
 from xesmf.data import wave_smooth
 from xesmf.util import grid_global
 from xclim.sdba.utils import equally_spaced_nodes
 from xclim import sdba, set_options
 from xclim.sdba.adjustment import QuantileDeltaMapping
-from xclim.core.calendar import convert_calendar
 from dodola.services import (
     bias_correct,
     build_weights,
@@ -566,7 +564,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
     np.random.seed(0)
     lon = [-99.83, -99.32, -99.79, -99.23]
     lat = [42.25, 42.21, 42.63, 42.59]
-    time = pd.date_range(start="1994-12-17", end="2015-01-15")
+    time = xr.cftime_range(start="1994-12-17", end="2015-01-15", calendar="noleap")
     temperature_ref = 15 + 8 * np.random.randn(len(time), 4, 4)
 
     ref_fine = xr.Dataset(
@@ -580,9 +578,6 @@ def test_aiqpd_train(tmpdir, monkeypatch):
         ),
         attrs=dict(description="Weather related data."),
     )
-
-    # remove leap days
-    ref_fine = convert_calendar(ref_fine["temperature"], target="noleap")
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
@@ -617,7 +612,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     )  # Avoid thread lock conflicts with dask scheduler
     lon = [-99.83, -99.32, -99.79, -99.23]
     lat = [42.25, 42.21, 42.63, 42.59]
-    time = pd.date_range(start="1994-12-17", end="2015-01-15")
+    time = xr.cftime_range(start="1994-12-17", end="2015-01-15", calendar="noleap")
     temperature_ref = 15 + 8 * np.random.randn(len(time), 4, 4)
     temperature_train = 15 + 8 * np.random.randn(len(time), 4, 4)
     variable = "scen"
@@ -645,10 +640,6 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
         ),
         attrs=dict(description="Weather related data."),
     )
-
-    # remove leap days
-    ref_fine = convert_calendar(ref_fine[variable], target="noleap")
-    ds_train = convert_calendar(ds_train[variable], target="noleap")
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -729,7 +729,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # check output
     downscaled_ds = xr.open_dataset(str(sim_downscaled_key))
 
-    downscaled_shape = (365, len(lon), len(lat))
+    downscaled_shape = (len(lon), len(lat), 365)
     # check that output is correct size
     assert downscaled_ds[variable].shape == downscaled_shape
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -722,7 +722,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     sim_downscaled_key = tmpdir.join("sim_downscaled.nc")
 
     # now train AIQPD model
-    train_aiqpd(ref_coarse_url, ref_fine_url, aiqpd_afs_url, "scen", "additive")
+    train_aiqpd(ref_coarse_url, ref_fine_url, aiqpd_afs_url, variable, "additive")
 
     # downscale
     apply_aiqpd(biascorrected_url, aiqpd_afs_url, variable, sim_downscaled_key)
@@ -731,8 +731,13 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     downscaled_ds = xr.open_dataset(str(sim_downscaled_key))
 
     downscaled_shape = (len(lon), len(lat), 365)
-
+    # check that output is correct size
     assert downscaled_ds[variable].shape == downscaled_shape
+
+    # check that downscaled average equals bias corrected value
+    bc_timestep = biascorrected_fine.isel(time=100).values[0][0]
+    aiqpd_downscaled_mean = downscaled_ds[variable].isel(time=100).mean().values
+    np.testing.assert_almost_equal(bc_timestep, aiqpd_downscaled_mean)
 
 
 @pytest.mark.parametrize(

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -569,7 +569,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
 
     ref_fine = xr.Dataset(
         data_vars=dict(
-            temperature=(["time", "lat", "lon"], temperature_ref),
+            scen=(["time", "lat", "lon"], temperature_ref),
         ),
         coords=dict(
             time=time,
@@ -590,7 +590,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
 
     repository.write(
         ref_coarse_url,
-        ref_coarse.to_dataset(name="scen").chunk({"time": -1}),
+        ref_coarse.chunk({"time": -1}),
     )
     repository.write(ref_fine_url, ref_fine.to_dataset(name="scen").chunk({"time": -1}))
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -729,10 +729,6 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # check output
     downscaled_ds = xr.open_dataset(str(sim_downscaled_key))
 
-    # downscaled_shape = (365, len(lon), len(lat))
-    # check that output is correct size
-    # assert downscaled_ds[variable].shape == downscaled_shape
-
     # check that downscaled average equals bias corrected value
     bc_timestep = biascorrected_fine.isel(time=100).values[0][0]
     aiqpd_downscaled_mean = downscaled_ds[variable].isel(time=100).mean().values

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -690,15 +690,10 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # Writes NC to local disk, so diff format here:
     sim_downscaled_key = tmpdir.join("sim_downscaled.nc")
 
-    repository.write(
-        ref_coarse_url,
-        ref_coarse.to_dataset(name="scen").chunk({"time": -1}),
-    )
-    repository.write(ref_fine_url, ref_fine.to_dataset(name="scen").chunk({"time": -1}))
+    repository.write(ref_coarse_url, ref_coarse.to_dataset(name="scen"))
+    repository.write(ref_fine_url, ref_fine.to_dataset(name="scen"))
 
-    repository.write(
-        bc_url, biascorrected_year.to_dataset(name="scen").chunk({"time": -1})
-    )
+    repository.write(bc_url, biascorrected_year.to_dataset(name="scen"))
 
     # now train AIQPD model
     train_aiqpd(ref_coarse_url, ref_fine_url, train_out_url, "scen", "additive")

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -691,12 +691,19 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     sim_downscaled_key = tmpdir.join("sim_downscaled.nc")
 
     repository.write(
-        ref_coarse_url, ref_coarse.to_dataset(name="scen").chunk({"time": -1})
+        ref_coarse_url,
+        ref_coarse.to_dataset(name="scen").chunk({"time": -1, "lat": -1, "lon": -1}),
     )
-    repository.write(ref_fine_url, ref_fine.to_dataset(name="scen").chunk({"time": -1}))
+    repository.write(
+        ref_fine_url,
+        ref_fine.to_dataset(name="scen").chunk({"time": -1, "lat": -1, "lon": -1}),
+    )
 
     repository.write(
-        bc_url, biascorrected_year.to_dataset(name="scen").chunk({"time": -1})
+        bc_url,
+        biascorrected_year.to_dataset(name="scen").chunk(
+            {"time": -1, "lat": -1, "lon": -1}
+        ),
     )
 
     # now train AIQPD model

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -729,7 +729,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # check output
     downscaled_ds = xr.open_dataset(str(sim_downscaled_key))
 
-    downscaled_shape = (len(lon), len(lat), 365)
+    downscaled_shape = (365, len(lon), len(lat))
     # check that output is correct size
     assert downscaled_ds[variable].shape == downscaled_shape
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -571,7 +571,7 @@ def test_aiqpd_train(tmpdir, monkeypatch):
 
     ref_fine = xr.Dataset(
         data_vars=dict(
-            air=(["time", "lat", "lon"], temperature_ref),
+            temperature=(["time", "lat", "lon"], temperature_ref),
         ),
         coords=dict(
             time=time,
@@ -623,7 +623,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
 
     ref_fine = xr.Dataset(
         data_vars=dict(
-            air=(["time", "lat", "lon"], temperature_ref),
+            temperature=(["time", "lat", "lon"], temperature_ref),
         ),
         coords=dict(
             time=time,
@@ -635,7 +635,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
 
     ds_train = xr.Dataset(
         data_vars=dict(
-            air=(["time", "lat", "lon"], temperature_train),
+            temperature=(["time", "lat", "lon"], temperature_train),
         ),
         coords=dict(
             time=time,

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -729,9 +729,9 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # check output
     downscaled_ds = xr.open_dataset(str(sim_downscaled_key))
 
-    downscaled_shape = (365, len(lon), len(lat))
+    # downscaled_shape = (365, len(lon), len(lat))
     # check that output is correct size
-    assert downscaled_ds[variable].shape == downscaled_shape
+    # assert downscaled_ds[variable].shape == downscaled_shape
 
     # check that downscaled average equals bias corrected value
     bc_timestep = biascorrected_fine.isel(time=100).values[0][0]

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -717,7 +717,6 @@ def test_aiqpd_integration(tmpdir, monkeypatch):
     # write test data
     aiqpd_afs_url = "memory://test_aiqpd_downscaling/a/aiqpd_afs/path.zarr"
 
-    # sim_key = "memory://test_apply_aiqpd/sim.zarr"
     # Writes NC to local disk, so diff format here:
     sim_downscaled_key = tmpdir.join("sim_downscaled.nc")
 


### PR DESCRIPTION
Updates `adjust` step in the AIQPD downscaling method (breaking backwards compatibility), updates `train` test and adds AIQPD integration test between QDM and AIQPD services. 

New `adjust` interface is: 

```bash
dodola apply-aiqpd --simulation /path/to/biascorrected.zarr \
    --aiqpd /path/to/adjustfactors.zarr \
    -v "tasmax" 
    --out /path/to/adjusted.nc \
```

closes #111 and #113
