### PR TITLE
Add global validation

### DIFF
--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -321,3 +321,30 @@ def regrid(x, out, method, domain_file, weightspath, astype, cyclic):
 def correct_wetday_frequency(x, out, process):
     """Correct wet day frequency in a dataset"""
     services.correct_wet_day_frequency(str(x), out=str(out), process=str(process))
+
+
+@dodola_cli.command(help="Validate a CMIP6, bias corrected or downscaled dataset")
+@click.argument("x", required=True)
+@click.option("--variable", "-v", required=True)
+@click.option(
+    "--data_type",
+    "-data",
+    required=True,
+    type=click.Choice(["cmip6", "bias_corrected", "downscaled"], case_sensitive=False),
+    help="Which data type to validate",
+)
+@click.option(
+    "--time_period",
+    "-time",
+    required=True,
+    type=click.Choice(["historical", "future"], case_sensitive=False),
+    help="Which time period to validate",
+)
+def validate_dataset(x, variable, data_type, time_period):
+    """Validate a dataset"""
+    services.validate_dataset(
+        str(x),
+        variable=str(variable),
+        data_type=str(data_type),
+        time_period=str(time_period),
+    )

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -14,6 +14,7 @@ from dodola.core import (
     adjust_quantiledeltamapping_year,
     train_analogdownscaling,
     adjust_analogdownscaling,
+    validate_dataset,
 )
 import dodola.repository as storage
 
@@ -435,6 +436,28 @@ def correct_wet_day_frequency(x, out, process):
     ds = storage.read(x)
     ds_corrected = apply_wet_day_frequency_correction(ds, process=process)
     storage.write(out, ds_corrected)
+
+
+@log_service
+def validate(x, var, data_type, time_period):
+    """Performs validation on an input dataset
+
+    Parameters
+    ----------
+    x : str
+        Storage URL to input xr.Dataset that will be validated.
+    var : {"tasmax", "tasmin", "dtr", "pr"}
+        Variable in xr.Dataset that should be validated.
+        Some validation functions are specific to each variable.
+    data_type : {"cmip6", "bias_corrected", "downscaled"}
+        Step in pipeline, used in determining how to validate.
+    time_period: {"historical", "future"}
+        Time period that input data should cover, used in validating the number of timesteps
+        in conjunction with the data type.
+    """
+
+    ds = storage.read(x)
+    validate_dataset(ds)
 
 
 @log_service

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -862,25 +862,6 @@ def test_downscale(domain_file, method, var):
     np.testing.assert_almost_equal(downscaled_ds.values, downscaled_test.values)
 
 
-def test_clean_cmip6():
-    """Tests that cmip6 cleanup removes extra dimensions on dataset"""
-    # Setup input data
-    n = 1500  # need over four years of daily data
-    ts = np.sin(np.linspace(-10 * np.pi, 10 * np.pi, n)) * 0.5
-    ds_gcm = _gcmfactory(ts, start_time="1950-01-01")
-
-    in_url = "memory://test_clean_cmip6/an/input/path.zarr"
-    out_url = "memory://test_clean_cmip6/an/output/path.zarr"
-    repository.write(in_url, ds_gcm)
-
-    clean_cmip6(in_url, out_url, leapday_removal=True)
-    ds_cleaned = repository.read(out_url)
-
-    assert "height" not in ds_cleaned.coords
-    assert "member_id" not in ds_cleaned.coords
-    assert "time_bnds" not in ds_cleaned.coords
-
-
 @pytest.mark.parametrize(
     "variable",
     [


### PR DESCRIPTION
This PR adds global validation for tasmax, tasmin, dtr and pr. It supports validation of cleaned CMIP6, bias corrected and downscaled data for historical and future time periods. It includes a new service called `validate` with CLI interface: 

```
dodola validate /path/to/dataset_to_validate.zarr \
--v "tasmax" 
--data "bias_corrected"
--time "future"
```

closes #69 