### PR TITLE
update xclim version after merging in newest xclim changes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
+* Update xclim version to 0.30.1, this updates the Train/Adjust API for QDM and AIQPD and requires units attributes for all QDM and AIQPD inputs (PR #119, @dgergel)
 * Add global validation, includes new service ``validate`` for validating cleaned CMIP6, bias corrected and downscaled data for historical and future time periods. (PR #118, @dgergel) 
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -155,12 +155,13 @@ def train_analogdownscaling(
             )
         )
 
-    aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling(
+    aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.train(
+        coarse_reference[variable],
+        fine_reference[variable],
         kind=str(kind),
         group=sdba.Grouper("time.dayofyear", window=int(window_n)),
         nquantiles=quantiles_n,
     )
-    aiqpd.train(coarse_reference[variable], fine_reference[variable])
     return aiqpd
 
 
@@ -233,9 +234,11 @@ def apply_bias_correction(
         # instantiates a grouper class that groups by day of the year
         # centered window: +/-15 day group
         group = sdba.Grouper("time.dayofyear", window=31)
-        model = sdba.adjustment.QuantileDeltaMapping(group=group, kind="+")
-        model.train(
-            ref=obs_training_ds[train_variable], hist=gcm_training_ds[train_variable]
+        model = sdba.adjustment.QuantileDeltaMapping.train(
+            ref=obs_training_ds[train_variable],
+            hist=gcm_training_ds[train_variable],
+            group=group,
+            kind="+",
         )
         predicted = model.adjust(sim=gcm_predict_ds[train_variable])
     else:

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -50,7 +50,6 @@ def train_quantiledeltamapping(
         group=sdba.Grouper("time.dayofyear", window=int(window_n)),
         nquantiles=equally_spaced_nodes(int(quantiles_n), eps=None),
     )
-    # qdm.train(ref=reference[variable], hist=historical[variable])
     return qdm
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -44,11 +44,13 @@ def train_quantiledeltamapping(
     xclim.sdba.adjustment.QuantileDeltaMapping
     """
     qdm = sdba.adjustment.QuantileDeltaMapping(
+        ref=reference[variable],
+        hist=historical[variable],
         kind=str(kind),
         group=sdba.Grouper("time.dayofyear", window=int(window_n)),
         nquantiles=equally_spaced_nodes(int(quantiles_n), eps=None),
     )
-    qdm.train(ref=reference[variable], hist=historical[variable])
+    # qdm.train(ref=reference[variable], hist=historical[variable])
     return qdm
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -156,8 +156,8 @@ def train_analogdownscaling(
         )
 
     aiqpd = sdba.adjustment.AnalogQuantilePreservingDownscaling.train(
-        coarse_reference[variable],
-        fine_reference[variable],
+        ref=coarse_reference[variable],
+        hist=fine_reference[variable],
         kind=str(kind),
         group=sdba.Grouper("time.dayofyear", window=int(window_n)),
         nquantiles=quantiles_n,

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -27,9 +27,9 @@ def train_quantiledeltamapping(
     Parameters
     ----------
     reference : xr.Dataset
-        Dataset to use as model reference.
+        Dataset to use as model reference. Target variable must have a units attribute.
     historical : xr.Dataset
-        Dataset to use as historical simulation.
+        Dataset to use as historical simulation. Target variable must have a units attribute.
     variable : str
         Name of target variable to extract from `historical` and `reference`.
     kind : {"+", "*"}
@@ -62,7 +62,7 @@ def adjust_quantiledeltamapping_year(
     ----------
     simulation : xr.Dataset
         Daily simulation data to be adjusted. Must have sufficient observations
-        around `year` to adjust.
+        around `year` to adjust. Target variable must have a units attribute.
     qdm : xr.Dataset or sdba.adjustment.QuantileDeltaMapping
         Trained ``xclim.sdba.adjustment.QuantileDeltaMapping``, or
         Dataset representation that will be instantiate
@@ -120,9 +120,9 @@ def train_analogdownscaling(
     Parameters
     ----------
     coarse_reference : xr.Dataset
-        Dataset to use as resampled (to fine resolution) coarse reference.
+        Dataset to use as resampled (to fine resolution) coarse reference.Target variable must have a units attribute.
     fine_reference : xr.Dataset
-        Dataset to use as fine-resolution reference.
+        Dataset to use as fine-resolution reference. Target variable must have a units attribute.
     variable : str
         Name of target variable to extract from `coarse_reference` and `fine_reference`.
     kind : {"+", "*"}
@@ -170,7 +170,7 @@ def adjust_analogdownscaling(simulation, aiqpd, variable):
     Parameters
     ----------
     simulation : xr.Dataset
-        Daily bias corrected data to be downscaled.
+        Daily bias corrected data to be downscaled. Target variable must have a units attribute.
     aiqpd : xr.Dataset or sdba.adjustment.AnalogQuantilePreservingDownscaling
         Trained ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling``, or
         Dataset representation that will instantiate

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -43,7 +43,7 @@ def train_quantiledeltamapping(
     -------
     xclim.sdba.adjustment.QuantileDeltaMapping
     """
-    qdm = sdba.adjustment.QuantileDeltaMapping(
+    qdm = sdba.adjustment.QuantileDeltaMapping.train(
         ref=reference[variable],
         hist=historical[variable],
         kind=str(kind),

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -149,7 +149,7 @@ def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
         kind=k,
     )
 
-    storage.write(out, aiqpd.ds)
+    storage.write(out, aiqpd)
 
 
 @log_service

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -149,7 +149,7 @@ def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
         kind=k,
     )
 
-    storage.write(out, aiqpd)
+    storage.write(out, aiqpd.ds)
 
 
 @log_service

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -22,6 +22,8 @@ def _timeseriesfactory(x, start_dt="1995-01-01", variable_name="fakevariable"):
     )
 
     out = xr.Dataset({variable_name: (["time"], x)}, coords={"time": time})
+    # need to set variable units to pass xclim 0.29 check on units
+    out[variable_name].attrs["units"] = "K"
     return out
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -42,6 +42,7 @@ def _datafactory(x, start_time="1950-01-01", variable_name="fakevariable"):
             "time": time,
             "lon": (["lon"], [1.0]),
             "lat": (["lat"], [1.0]),
+            "units": "fakeunits",
         },
     )
     out.attrs["units"] = "fakeunits"

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -611,6 +611,7 @@ def test_aiqpd_train(tmpdir, monkeypatch, kind):
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
     # tile the fine resolution grid with the coarse resolution ref data
     ref_coarse = ds_ref_coarse.broadcast_like(ref_fine)
+    ref_coarse["scen"].attrs["units"] = "K"
 
     # write test data
     ref_coarse_url = "memory://test_aiqpd_downscaling/a/ref_coarse/path.zarr"
@@ -680,7 +681,9 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
     ds_train = ds_train.mean(["lat", "lon"])
     # tile the fine resolution grid with the coarse resolution ref data
     ref_coarse = ds_ref_coarse.broadcast_like(ref_fine)
+    ref_coarse["scen"].attrs["units"] = "K"
     ds_bc = ds_train + 3
+    ds_bc["scen"].attrs["units"] = "K"
 
     # write test data
     ref_coarse_coarse_url = (

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -44,6 +44,7 @@ def _datafactory(x, start_time="1950-01-01", variable_name="fakevariable"):
             "lat": (["lat"], [1.0]),
         },
     )
+    # need to set variable units to pass xclim 0.29 check on units
     out[variable_name].attrs["units"] = "K"
     return out
 
@@ -68,6 +69,8 @@ def _modeloutputfactory(
             "lat": (["lat"], [1.0]),
         },
     )
+    # need to set variable units to pass xclim 0.29 check on units
+    out[variable_name].attrs["units"] = "K"
     return out
 
 
@@ -601,6 +604,8 @@ def test_aiqpd_train(tmpdir, monkeypatch, kind):
         ),
         attrs=dict(description="Weather related data."),
     )
+    # need to set variable units to pass xclim 0.29 check on units
+    ref_fine[scen].attrs["units"] = "K"
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
@@ -653,6 +658,8 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
         ),
         attrs=dict(description="Weather related data."),
     )
+    # need to set variable units to pass xclim 0.29 check on units
+    ref_fine[scen].attrs["units"] = "K"
 
     ds_train = xr.Dataset(
         data_vars=dict(
@@ -665,6 +672,8 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
         ),
         attrs=dict(description="Weather related data."),
     )
+    # need to set variable units to pass xclim 0.29 check on units
+    ds_train[scen].attrs["units"] = "K"
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -659,8 +659,6 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
         ),
         attrs=dict(description="Weather related data."),
     )
-    # need to set variable units to pass xclim 0.29 check on units
-    ref_fine["scen"].attrs["units"] = "K"
 
     ds_train = xr.Dataset(
         data_vars=dict(
@@ -677,12 +675,17 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
     ds_train = ds_train.mean(["lat", "lon"])
-    ds_train["scen"].attrs["units"] = "K"
+
     # tile the fine resolution grid with the coarse resolution ref data
     ref_coarse = ds_ref_coarse.broadcast_like(ref_fine)
-    ref_coarse["scen"].attrs["units"] = "K"
     ds_bc = ds_train + 3
+
+    # need to set variable units to pass xclim 0.29 check on units
+    ds_train["scen"].attrs["units"] = "K"
     ds_bc["scen"].attrs["units"] = "K"
+    ref_coarse["scen"].attrs["units"] = "K"
+    ref_fine["scen"].attrs["units"] = "K"
+    ds_ref_course["scen"].attrs["units"] = "K"
 
     # write test data
     ref_coarse_coarse_url = (

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -42,10 +42,9 @@ def _datafactory(x, start_time="1950-01-01", variable_name="fakevariable"):
             "time": time,
             "lon": (["lon"], [1.0]),
             "lat": (["lat"], [1.0]),
-            "units": "fakeunits",
         },
     )
-    out.attrs["units"] = "fakeunits"
+    out[variable_name].attrs["units"] = "K"
     return out
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -605,7 +605,7 @@ def test_aiqpd_train(tmpdir, monkeypatch, kind):
         attrs=dict(description="Weather related data."),
     )
     # need to set variable units to pass xclim 0.29 check on units
-    ref_fine[scen].attrs["units"] = "K"
+    ref_fine[variable].attrs["units"] = "K"
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
@@ -659,7 +659,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
         attrs=dict(description="Weather related data."),
     )
     # need to set variable units to pass xclim 0.29 check on units
-    ref_fine[scen].attrs["units"] = "K"
+    ref_fine[variable].attrs["units"] = "K"
 
     ds_train = xr.Dataset(
         data_vars=dict(
@@ -673,7 +673,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
         attrs=dict(description="Weather related data."),
     )
     # need to set variable units to pass xclim 0.29 check on units
-    ds_train[scen].attrs["units"] = "K"
+    ds_train[variable].attrs["units"] = "K"
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -44,6 +44,7 @@ def _datafactory(x, start_time="1950-01-01", variable_name="fakevariable"):
             "lat": (["lat"], [1.0]),
         },
     )
+    out.attrs["units"] = "fakeunits"
     return out
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -685,7 +685,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
     ds_bc["scen"].attrs["units"] = "K"
     ref_coarse["scen"].attrs["units"] = "K"
     ref_fine["scen"].attrs["units"] = "K"
-    ds_ref_course["scen"].attrs["units"] = "K"
+    ds_ref_coarse["scen"].attrs["units"] = "K"
 
     # write test data
     ref_coarse_coarse_url = (

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -673,12 +673,11 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
         ),
         attrs=dict(description="Weather related data."),
     )
-    # need to set variable units to pass xclim 0.29 check on units
-    ds_train["scen"].attrs["units"] = "K"
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
     ds_train = ds_train.mean(["lat", "lon"])
+    ds_train["scen"].attrs["units"] = "K"
     # tile the fine resolution grid with the coarse resolution ref data
     ref_coarse = ds_ref_coarse.broadcast_like(ref_fine)
     ref_coarse["scen"].attrs["units"] = "K"

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -605,7 +605,7 @@ def test_aiqpd_train(tmpdir, monkeypatch, kind):
         attrs=dict(description="Weather related data."),
     )
     # need to set variable units to pass xclim 0.29 check on units
-    ref_fine[variable].attrs["units"] = "K"
+    ref_fine["scen"].attrs["units"] = "K"
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])
@@ -659,7 +659,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
         attrs=dict(description="Weather related data."),
     )
     # need to set variable units to pass xclim 0.29 check on units
-    ref_fine[variable].attrs["units"] = "K"
+    ref_fine["scen"].attrs["units"] = "K"
 
     ds_train = xr.Dataset(
         data_vars=dict(
@@ -673,7 +673,7 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
         attrs=dict(description="Weather related data."),
     )
     # need to set variable units to pass xclim 0.29 check on units
-    ds_train[variable].attrs["units"] = "K"
+    ds_train["scen"].attrs["units"] = "K"
 
     # take the mean across space to represent coarse reference data for AFs
     ds_ref_coarse = ref_fine.mean(["lat", "lon"])

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@07ebc00c65979c6d551ce1f2854bb0ad5f940584
+  - git+https://github.com/ClimateImpactLab/xclim@dcbccda8055e76d1916c35e97599d917eab00290

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@caf9f60f4908dd21787407b17c83fb1d5a30edfc
+  - git+https://github.com/ClimateImpactLab/xclim@8958f7be44625c5e491c1685d71c2b596d5dca59

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@21ebefe0ecc49f031ff43cccea12f70404946f9c
+  - git+https://github.com/ClimateImpactLab/xclim@6a231ab52a9a4a3f10c39b87e92a5465175eb1e2

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@c5507ba29c19f957270789fd790ffe6c315a3daa
+  - git+https://github.com/ClimateImpactLab/xclim@658f26990d3764d663b2e30ca79590d9508d2f04

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@5b21e449a4012311e2ff40741b8436e808ab6d48
+  - git+https://github.com/ClimateImpactLab/xclim@07ebc00c65979c6d551ce1f2854bb0ad5f940584

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@dc8831d868e10a951fe3cb2e833005aa913c6c06
+  - git+https://github.com/ClimateImpactLab/xclim@50727adef6a86e039918e5914327046f4aba6ebe

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@50727adef6a86e039918e5914327046f4aba6ebe
+  - git+https://github.com/ClimateImpactLab/xclim@caf9f60f4908dd21787407b17c83fb1d5a30edfc

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@8958f7be44625c5e491c1685d71c2b596d5dca59
+  - git+https://github.com/ClimateImpactLab/xclim@ac1f3cce52d98c01fcfab3e5b8e01584722e797d

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@dcbccda8055e76d1916c35e97599d917eab00290
+  - git+https://github.com/ClimateImpactLab/xclim@21ebefe0ecc49f031ff43cccea12f70404946f9c

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@6a231ab52a9a4a3f10c39b87e92a5465175eb1e2
+  - git+https://github.com/ClimateImpactLab/xclim@dc8831d868e10a951fe3cb2e833005aa913c6c06

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,4 +24,4 @@ dependencies:
 - zarr=2.8.3
 - pip:
   - git+https://github.com/dgergel/xsd@458f292dab6e8a6584659e97a66c37e028da2b7a
-  - git+https://github.com/ClimateImpactLab/xclim@658f26990d3764d663b2e30ca79590d9508d2f04
+  - git+https://github.com/ClimateImpactLab/xclim@5b21e449a4012311e2ff40741b8436e808ab6d48


### PR DESCRIPTION
Update `xclim` version to 0.30.1 in our fork, adds support for 360-day calendars. 

This PR also adds `breaking` changes for the QDM and AIQPD implementations to make them consistent with the major `xclim` 0.29 updates and requires that all inputs to QDM and AIQPD have units attributes that are compatible with `pint` units. 