### PR TITLE
Add pre-training slicing options to train-qdm and train-aiqpd

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* 
+* Add pre-training slicing options to train-qdm and train-aiqpd. (PR #123, @brews)
 
 
 0.7.0 (2021-11-02)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -97,20 +97,20 @@ def train_qdm(
     historical, reference, out, variable, kind, selslice=None, iselslice=None
 ):
     """Train Quantile Delta Mapping (QDM) model and output to storage"""
-    sel_slices = None
-    isel_slices = None
+    sel_slices_d = None
+    isel_slices_d = None
 
     if selslice:
-        sel_slices = {}
+        sel_slices_d = {}
         for s in selslice:
             k, v = s.split("=")
-            sel_slices[k] = slice(*map(str, v.split(",")))
+            sel_slices_d[k] = slice(*map(str, v.split(",")))
 
     if iselslice:
-        isel_slices = {}
+        isel_slices_d = {}
         for s in iselslice:
             k, v = s.split("=")
-            isel_slices[k] = slice(*map(int, v.split(",")))
+            isel_slices_d[k] = slice(*map(int, v.split(",")))
 
     services.train_qdm(
         historical=historical,
@@ -118,8 +118,8 @@ def train_qdm(
         out=out,
         variable=variable,
         kind=kind,
-        sel_slices=sel_slices,
-        isel_slices=isel_slices,
+        sel_slice=sel_slices_d,
+        isel_slice=isel_slices_d,
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -81,14 +81,45 @@ def apply_qdm(simulation, qdm, year, variable, out, include_quantiles):
     help="Variable kind for mapping",
 )
 @click.option("--out", "-o", required=True, help="URL to write QDM model to")
-def train_qdm(historical, reference, out, variable, kind):
+@click.option(
+    "--selslice",
+    multiple=True,
+    required=False,
+    help="variable=start,stop to 'isel' slice inputs before training",
+)
+@click.option(
+    "--iselslice",
+    multiple=True,
+    required=False,
+    help="variable=start,stop to 'sel' slice inputs before training",
+)
+def train_qdm(
+    historical, reference, out, variable, kind, selslice=None, iselslice=None
+):
     """Train Quantile Delta Mapping (QDM) model and output to storage"""
+    sel_slices = None
+    isel_slices = None
+
+    if selslice:
+        sel_slices = {}
+        for s in selslice:
+            k, v = s.split("=")
+            sel_slices[k] = slice(*map(str, v.split(",")))
+
+    if iselslice:
+        isel_slices = {}
+        for s in iselslice:
+            k, v = s.split("=")
+            isel_slices[k] = slice(*map(int, v.split(",")))
+
     services.train_qdm(
         historical=historical,
         reference=reference,
         out=out,
         variable=variable,
         kind=kind,
+        sel_slices=sel_slices,
+        isel_slices=isel_slices,
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -272,7 +272,7 @@ def downscale(
     adjustmentfactors,
     weightspath,
 ):
-    """Downscale bias corrected GCM to 'out' based on obs climo (yclimocoarse, yclimofine) using (method) and (domain_file)"""
+    """Downscale biascorrected to out based on climo"""
     services.downscale(
         x,
         yclimocoarse,

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -165,14 +165,45 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
     help="Variable kind for mapping",
 )
 @click.option("--out", "-o", required=True, help="URL to write QDM model to")
-def train_aiqpd(coarse_reference, fine_reference, out, variable, kind):
+@click.option(
+    "--selslice",
+    multiple=True,
+    required=False,
+    help="variable=start,stop to 'isel' slice inputs before training",
+)
+@click.option(
+    "--iselslice",
+    multiple=True,
+    required=False,
+    help="variable=start,stop to 'sel' slice inputs before training",
+)
+def train_aiqpd(
+    coarse_reference, fine_reference, out, variable, kind, selslice=None, iselslice=None
+):
     """Train Analog-Inspired Quantile Preserving Downscaling (AIQPD) model and output to storage"""
+    sel_slices_d = None
+    isel_slices_d = None
+
+    if selslice:
+        sel_slices_d = {}
+        for s in selslice:
+            k, v = s.split("=")
+            sel_slices_d[k] = slice(*map(str, v.split(",")))
+
+    if iselslice:
+        isel_slices_d = {}
+        for s in iselslice:
+            k, v = s.split("=")
+            isel_slices_d[k] = slice(*map(int, v.split(",")))
+
     services.train_aiqpd(
         coarse_reference=coarse_reference,
         fine_reference=fine_reference,
         out=out,
         variable=variable,
         kind=kind,
+        sel_slice=sel_slices_d,
+        isel_slice=isel_slices_d,
     )
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -285,7 +285,8 @@ def apply_downscaling(
     af_fine : xr.Dataset
         A dataset of adjustment factors at fine resolution used in downscaling.
     ds_downscaled : xr.Dataset
-        A model dataset that has been downscaled from the bias correction resolution to specified domain file resolution.
+        A model dataset that has been downscaled from the bias correction
+        resolution to specified domain file resolution.
     """
 
     if method == "BCSD":
@@ -476,7 +477,10 @@ def apply_wet_day_frequency_correction(ds, process):
 
     Notes
     -------
-    [1] A.J. Cannon, S.R. Sobie, & T.Q. Murdock, "Bias correction of GCM precipitation by quantile mapping: How well do methods preserve changes in quantiles and extremes?", Journal of Climate, vol. 28, Issue 7, pp. 6938-6959.
+    [1] A.J. Cannon, S.R. Sobie, & T.Q. Murdock, "Bias correction of GCM
+        precipitation by quantile mapping: How well do methods preserve
+        changes in quantiles and extremes?", Journal of Climate, vol.
+        28, Issue 7, pp. 6938-6959.
     """
     threshold = 0.05  # mm/day
     low = 1e-16

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -71,12 +71,12 @@ def train_qdm(
         raise ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
 
     if sel_slice:
-        logger.debug(f"slicing by {sel_slice =}")
+        logger.debug(f"Slicing by {sel_slice=}")
         hist = hist.sel(sel_slice)
         ref = ref.sel(sel_slice)
 
     if isel_slice:
-        logger.debug(f"slicing by {isel_slice =}")
+        logger.debug(f"Slicing by {isel_slice=}")
         hist = hist.isel(isel_slice)
         ref = ref.isel(isel_slice)
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -502,9 +502,3 @@ def validate(x, var, data_type, time_period):
 
     ds = storage.read(x)
     validate_dataset(ds, var, data_type, time_period)
-
-
-@log_service
-def disaggregate(x, weights, out, repo):
-    """This is just an example. Please replace or delete."""
-    raise NotImplementedError

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -2,8 +2,6 @@ import numpy as np
 import pytest
 import xarray as xr
 import cftime
-from xclim.sdba.utils import equally_spaced_nodes
-from xclim import sdba, set_options
 from dodola.core import (
     train_quantiledeltamapping,
     adjust_quantiledeltamapping_year,

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -59,6 +59,9 @@ def _modeloutputfactory(
     np.random.seed(0)
     time = xr.cftime_range(start=start_time, end=end_time, calendar="noleap")
     # make sure that test data range is reasonable for the variable being tested
+
+    low_val = None
+    high_val = None
     if variable_name == "tasmax" or variable_name == "tasmin":
         low_val = 160
         high_val = 340
@@ -985,6 +988,7 @@ def test_downscale(domain_file, method, var):
     )
 
     # compute adjustment factor
+    af_coarse = None
     if var == "temperature":
         af_coarse = ds_bc.groupby("time.dayofyear") - climo_coarse
     elif var == "precipitation":
@@ -1029,6 +1033,7 @@ def test_downscale(domain_file, method, var):
     af_fine = repository.read(af_fine_url)[var]
 
     # compute test downscaled values
+    downscaled_test = None
     if var == "temperature":
         downscaled_test = af_fine.groupby("time.dayofyear") + climo_fine
     elif var == "precipitation":
@@ -1057,6 +1062,8 @@ def test_downscale(domain_file, method, var):
 def test_validation(variable, data_type, time_period):
     """Tests that validate passes for fake output data"""
     # Setup input data
+    start_time = None
+    end_time = None
     if data_type == "bias_corrected" or data_type == "downscaled":
         if time_period == "historical":
             start_time = "1950-01-01"


### PR DESCRIPTION
This PR adds `--iselslice` and `--selslice` to `train-qdm` and `train-aiqpd` (and their twins in`dodola.services`).

This means you can do something like

```bash
dodola --debug train-qdm -v "tasmax" \
  -h "gs://scratch-170cd6ec/biascorrectdownscale-fqpdn/biascorrectdownscale-fqpdn-1975355103/rechunked.zarr" \
  -r "gs://scratch-170cd6ec/biascorrectdownscale-fqpdn/biascorrectdownscale-fqpdn-4235871458/rechunked.zarr" \
  -k "additive" \
  --iselslice "lat=170,180" \
  --out "/home/cooluser/Downloads/dodola_test.zarr"
```

and it will slice the data with `xr.Dataset.isel` before the model is trained.

This feature is helpful for larger, automated, orchestrated that don't use an external dask distributed scheduler, or train a larger dataset in local memory.

Some shoddy, but effective tests are included for the new behavior at the `dodola.services` level.

The PR includes some minor style cleanup and cruft removal across the package.