### PR TITLE
Quick fix validation reading entire zarr store for QC check

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 0.X.X (XXXX-XX-XX)
 ------------------
 * Add pre-training slicing options to train-qdm and train-aiqpd. (PR #123, @brews)
+* Quick fix validation reading entire zarr store for check. (@brews)
 
 
 0.7.0 (2021-11-02)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 0.X.X (XXXX-XX-XX)
 ------------------
 * Add pre-training slicing options to train-qdm and train-aiqpd. (PR #123, @brews)
-* Quick fix validation reading entire zarr store for check. (@brews)
+* Quick fix validation reading entire zarr store for check. (PR #124, @brews)
 
 
 0.7.0 (2021-11-02)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -542,13 +542,12 @@ def validate_dataset(ds, var, data_type, time_period="future"):
         # Assumes error thrown if had problem before this.
         return True
 
-    tasks = []
+    results = []
     for t in np.unique(ds["time"].dt.year.data):
-        logger.debug(f"Validating for year {t}")
-        test_results = memory_intensive_tests(ds, var, t)
-        tasks.append(test_results)
-    tasks = dask.compute(*tasks)
-    assert all(tasks)  # Likely don't need this
+        logger.debug(f"Validating year {t}")
+        results.append(memory_intensive_tests(ds, var, t))
+    results = dask.compute(*results)
+    assert all(results)  # Likely don't need this
     return True
 
 


### PR DESCRIPTION
Validation tries to read entire Zarr stores into memory to perform some checks.

This PR implements the work-around in https://github.com/ClimateImpactLab/downscaleCMIP6/blob/0122ce6730de73c6b64b8e9ca120e2bfaf95e7bb/workflows/templates/qualitycontrol-check-cmip6.yaml#L47 as a quick fix to the problem. Basically reading annual slices through via dask.delayed.