### PR TITLE
Fix ValueError from chunks in time in existing workflows

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Add pre-training slicing options to train-qdm and train-aiqpd. (PR #123, @brews)
+* Add pre-training slicing options to train-qdm and train-aiqpd. (PR #123, PR #128, @brews)
 * Quick fix validation reading entire zarr store for check. (PR #124, @brews)
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -186,6 +186,10 @@ def train_aiqpd(
         ref_coarse = ref_coarse.isel(isel_slice)
         ref_fine = ref_fine.isel(isel_slice)
 
+    # needs to not be chunked
+    ref_coarse.load()
+    ref_fine.load()
+
     aiqpd = train_analogdownscaling(
         coarse_reference=ref_coarse,
         fine_reference=ref_fine,


### PR DESCRIPTION
Fixes bug from: 'ValueError: ... Multiple chunks along the main adjustment dimension time is not supported' when running `dodola train-aiqpd`. 

We get this from running the new `dodola train-aiqpd` in legacy workflows. Ideally, we'd resolve this by changing chunking in upstream workflow steps, but `train_aiqpd` was written so we would not need to address these kinds of breaking changes until a later time. In other words, `train_aiqpd` needs to support bad input dataset chunking to support legacy. This PR fixes it so that it does so.