### PR TITLE
Add QDM output Zarr priming, region writing, metadata, multi-year processing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
+* Add QDM output Zarr priming (`prime-qdm-output-zarrstore`), region writing, multi-year processing. This breaks backwards compatibility for `apply-qdm` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
 * Add pre-training slicing options to train-qdm and train-aiqpd. (PR #123, PR #128, @brews)
 * Quick fix validation reading entire zarr store for check. (PR #124, @brews)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Add QDM output Zarr priming (``prime-qdm-output-zarrstore``), region writing, multi-year processing. This breaks backwards compatibility for ``apply-qdm`` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
+* Add QDM output Zarr priming (``prime-qdm-output-zarrstore``), region writing, attrs merging, and multi-year processing. This breaks backwards compatibility for ``apply-qdm`` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
 * Make logging slightly more chatty by default. (PR #129, @brews)
 * Add pre-training slicing options to ``train-qdm`` and ``train-aiqpd``. (PR #123, PR #128, @brews)
 * Quick fix validation reading entire zarr store for check. (PR #124, @brews)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 0.X.X (XXXX-XX-XX)
 ------------------
 * Add QDM output Zarr priming (`prime-qdm-output-zarrstore`), region writing, multi-year processing. This breaks backwards compatibility for `apply-qdm` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
+* Make logging slightly more chatty by default. (PR #129, @brews)
 * Add pre-training slicing options to train-qdm and train-aiqpd. (PR #123, PR #128, @brews)
 * Quick fix validation reading entire zarr store for check. (PR #124, @brews)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,9 +5,9 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Add QDM output Zarr priming (`prime-qdm-output-zarrstore`), region writing, multi-year processing. This breaks backwards compatibility for `apply-qdm` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
+* Add QDM output Zarr priming (``prime-qdm-output-zarrstore``), region writing, multi-year processing. This breaks backwards compatibility for ``apply-qdm`` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
 * Make logging slightly more chatty by default. (PR #129, @brews)
-* Add pre-training slicing options to train-qdm and train-aiqpd. (PR #123, PR #128, @brews)
+* Add pre-training slicing options to ``train-qdm`` and ``train-aiqpd``. (PR #123, PR #128, @brews)
 * Quick fix validation reading entire zarr store for check. (PR #124, @brews)
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -63,11 +63,13 @@ def dodola_cli(debug):
     multiple=True,
     help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
 )
-def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dims=None, new_attrs=None):
+def prime_qdm_output_zarrstore(
+    simulation, variable, years, out, zarr_region_dims=None, new_attrs=None
+):
     """Initialize a Zarr Store for writing QDM output regionally in independent processes"""
     first_year, last_year = (int(x) for x in years.split(","))
 
-    unpacked_attrs=None
+    unpacked_attrs = None
     if new_attrs:
         unpacked_attrs = {k: v for x in new_attrs for k, v in (x.split("="),)}
 
@@ -78,7 +80,7 @@ def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dim
         variable=variable,
         out=out,
         zarr_region_dims=region_dims,
-        new_attrs=unpacked_attrs
+        new_attrs=unpacked_attrs,
     )
 
 
@@ -131,12 +133,12 @@ def apply_qdm(
     selslice=None,
     iselslice=None,
     out_zarr_region=None,
-    new_attrs=None
+    new_attrs=None,
 ):
     """Adjust simulation years with QDM bias correction method, outputting Zarr Store"""
     first_year, last_year = (int(x) for x in years.split(","))
 
-    unpacked_attrs=None
+    unpacked_attrs = None
     if new_attrs:
         unpacked_attrs = {k: v for x in new_attrs for k, v in (x.split("="),)}
 
@@ -172,7 +174,7 @@ def apply_qdm(
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
         out_zarr_region=out_zarr_region_d,
-        new_attrs=unpacked_attrs
+        new_attrs=unpacked_attrs,
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -138,7 +138,7 @@ def apply_qdm(
         out_zarr_region_d = {}
         for s in out_zarr_region:
             k, v = s.split("=")
-            isel_slices_d[k] = slice(*map(int, v.split(",")))
+            out_zarr_region_d[k] = slice(*map(int, v.split(",")))
 
     services.apply_qdm(
         simulation=simulation,

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -58,9 +58,19 @@ def dodola_cli(debug):
     required=True,
     help="'variable1,variable2' comma-delimited list of variables used to define region when writing",
 )
-def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dims=None):
+@click.option(
+    "--new-attrs",
+    multiple=True,
+    help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
+)
+def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dims=None, new_attrs=None):
     """Initialize a Zarr Store for writing QDM output regionally in independent processes"""
     first_year, last_year = (int(x) for x in years.split(","))
+
+    unpacked_attrs=None
+    if new_attrs:
+        unpacked_attrs = {k: v for x in new_attrs for k, v in (x.split("="),)}
+
     region_dims = zarr_region_dims.split(",")
     services.prime_qdm_output_zarrstore(
         simulation=simulation,
@@ -68,6 +78,7 @@ def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dim
         variable=variable,
         out=out,
         zarr_region_dims=region_dims,
+        new_attrs=unpacked_attrs
     )
 
 
@@ -106,6 +117,11 @@ def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dim
     required=False,
     help="variable=start,stop index to write output to region of existing Zarr Store",
 )
+@click.option(
+    "--new-attrs",
+    multiple=True,
+    help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
+)
 def apply_qdm(
     simulation,
     qdm,
@@ -115,9 +131,14 @@ def apply_qdm(
     selslice=None,
     iselslice=None,
     out_zarr_region=None,
+    new_attrs=None
 ):
     """Adjust simulation years with QDM bias correction method, outputting Zarr Store"""
     first_year, last_year = (int(x) for x in years.split(","))
+
+    unpacked_attrs=None
+    if new_attrs:
+        unpacked_attrs = {k: v for x in new_attrs for k, v in (x.split("="),)}
 
     sel_slices_d = None
     if selslice:
@@ -151,6 +172,7 @@ def apply_qdm(
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
         out_zarr_region=out_zarr_region_d,
+        new_attrs=unpacked_attrs
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -54,7 +54,7 @@ def dodola_cli(debug):
     help="URL to write Zarr Store with adjusted simulation year to",
 )
 @click.option(
-    "--zarr_region_dims",
+    "--zarr-region-dims",
     required=True,
     help="'variable1,variable2' comma-delimited list of variables used to define region when writing",
 )

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -43,10 +43,11 @@ def write(url_or_path, x, region=None):
         are dropped.
     """
     logger.debug(f"Writing {url_or_path}")
+    logger.debug(f"Output Dataset {x=}")
 
     if region:
         # TODO: This behavior needs a better, focused, unit test.
-        logger.debug(f"Writing to Zarr Store region, {region=}")
+        logger.info(f"Writing to Zarr Store region, {region=}")
 
         # We need to drop all variables not sliced by the selected zarr_region.
         variables_to_drop = []
@@ -58,8 +59,8 @@ def write(url_or_path, x, region=None):
             ):
                 variables_to_drop.append(variable_name)
 
-        logger.debug(
-            f"Dropping variables before Zarr regional write: {variables_to_drop=}"
+        logger.info(
+            f"Dropping variables before Zarr region write: {variables_to_drop=}"
         )
         x = x.drop_vars(variables_to_drop)
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -35,7 +35,9 @@ def log_service(func):
 
 
 @log_service
-def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dims, new_attrs=None):
+def prime_qdm_output_zarrstore(
+    simulation, variable, years, out, zarr_region_dims, new_attrs=None
+):
     """Init a Zarr Store for writing QDM output regionally in independent processes.
 
     Parameters
@@ -170,7 +172,7 @@ def apply_qdm(
     sel_slice=None,
     isel_slice=None,
     out_zarr_region=None,
-    new_attrs=None
+    new_attrs=None,
 ):
     """Apply trained QDM to adjust a years in a simulation, write to Zarr Store.
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -11,7 +11,7 @@ from dodola.core import (
     apply_downscaling,
     apply_wet_day_frequency_correction,
     train_quantiledeltamapping,
-    adjust_quantiledeltamapping_year,
+    adjust_quantiledeltamapping,
     train_analogdownscaling,
     adjust_analogdownscaling,
     validate_dataset,
@@ -32,6 +32,76 @@ def log_service(func):
         logger.info(f"dodola service {servicename} done")
 
     return service_logger
+
+
+@log_service
+def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dims):
+    """Init a Zarr Store for writing QDM output regionally in independent processes.
+
+    Parameters
+    ----------
+    simulation : str
+        fsspec-compatible URL containing simulation data to be adjusted.
+    variable : str
+        Target variable in `simulation` to adjust. Adjusted output will share the
+        same name.
+    years : sequence of ints
+        Years of simulation to adjust, with rolling years and day grouping.
+    out : str
+        fsspec-compatible path or URL pointing to Zarr Store file where the
+        QDM-adjusted simulation data will be written.
+    zarr_region_dims: sequence of str
+        Sequence giving the name of dimensions that will be used to later write
+        to regions of the Zarr Store. Variables with dimensions that do not use
+        these regional variables will be appended to the primed Zarr Store as
+        part of this call.
+    """
+    # TODO: Options to change primed output zarr store chunking?
+    import xarray as xr  # TODO: Clean up this import or move the import-depending code to doodla.core
+
+    quantile_variable_name = "sim_q"
+    sim_df = storage.read(simulation)
+
+    # Yes, the time slice needs to use strs, not ints. It's already going to be inclusive so don't need to +1.
+    primer = sim_df.sel(time=slice(str(min(years)), str(max(years))))
+
+    ## This is where chunking happens... not sure about whether this is needed or how to effectively handle this.
+    # primed_out = dodola.repository.read(simulation_zarr).sel(time=timeslice).chunk({"time": 73, "lat": 10, "lon":180})
+
+    primer[quantile_variable_name] = xr.zeros_like(primer[variable])
+    # Analysts said sim_q needed no attrs.
+    primer[quantile_variable_name].attrs = {}
+
+    # Add metadata to outgoing Dataset here.
+
+    # Logic below might be better off in dodola.repository.
+    logger.debug(f"Priming Zarr Store with {primer=}")
+    primer.to_zarr(
+        out,
+        mode="w",
+        compute=False,
+        consolidated=True,
+        safe_chunks=False,
+    )
+    logger.info(f"Written primer to {out}")
+
+    # Append variables that do not depend on dims we're using to define the
+    # region we'll later write to in the Zarr Store.
+    variables_to_append = []
+    for variable_name, variable in primer.variables.items():
+        if any(
+            region_variable not in variable.dims for region_variable in zarr_region_dims
+        ):
+            variables_to_append.append(variable_name)
+
+    if variables_to_append:
+        logger.debug(f"Appending {variables_to_append=} to primed Zarr Store")
+        primer[variables_to_append].to_zarr(
+            out, mode="a", compute=True, consolidated=True, safe_chunks=False
+        )
+        logger.info(f"Appended non-regional variables to {out}")
+    else:
+        logger.info("No non-regional variables to append to Zarr Store")
 
 
 @log_service
@@ -88,10 +158,20 @@ def train_qdm(
 
 
 @log_service
-def apply_qdm(simulation, qdm, year, variable, out, include_quantiles=False):
-    """Apply trained QDM to adjust a year within a simulation, dump to NetCDF.
+def apply_qdm(
+    simulation,
+    qdm,
+    years,
+    variable,
+    out,
+    sel_slice=None,
+    isel_slice=None,
+    out_zarr_region=None,
+):
+    """Apply trained QDM to adjust a years in a simulation, write to Zarr Store.
 
-    Dumping to NetCDF is a feature likely to change in the near future.
+    Output includes bias-corrected variable `variable` as well as a variable giving quantiles
+    from the QDM, "sim_q".
 
     Parameters
     ----------
@@ -100,38 +180,51 @@ def apply_qdm(simulation, qdm, year, variable, out, include_quantiles=False):
     qdm : str
         fsspec-compatible URL pointing to Zarr Store containing canned
         ``xclim.sdba.adjustment.QuantileDeltaMapping`` Dataset.
-    year : int
-        Target year to adjust, with rolling years and day grouping.
+    years : sequence of ints
+        Years of simulation to adjust, with rolling years and day grouping.
     variable : str
         Target variable in `simulation` to adjust. Adjusted output will share the
         same name.
     out : str
-        fsspec-compatible path or URL pointing to NetCDF4 file where the
+        fsspec-compatible path or URL pointing to Zarr Store file where the
         QDM-adjusted simulation data will be written.
-    include_quantiles : bool
-        Flag to indicate whether bias-corrected quantiles should be
-        included in the QDM-adjusted output.
+    sel_slice: dict or None, optional
+        Label-index slice input slimulation dataset before adjusting.
+        A mapping of {variable_name: slice(...)} passed to
+        `xarray.Dataset.sel()`.
+    isel_slice: dict or None, optional
+        Integer-index slice input slimulation dataset before adjusting. A mapping
+        of {variable_name: slice(...)} passed to `xarray.Dataset.isel()`.
+    out_zarr_region: dict or None, optional
+        A mapping of {variable_name: slice(...)} giving the region to write
+        to if outputting to existing Zarr Store.
     """
     sim_ds = storage.read(simulation)
     qdm_ds = storage.read(qdm)
 
-    year = int(year)
+    if sel_slice:
+        logger.debug(f"Slicing by {sel_slice=}")
+        sim_ds = sim_ds.sel(sel_slice)
+
+    if isel_slice:
+        logger.debug(f"Slicing by {isel_slice=}")
+        sim_ds = sim_ds.isel(isel_slice)
+
     variable = str(variable)
 
-    adjusted_ds = adjust_quantiledeltamapping_year(
+    qdm_ds.load()
+    sim_ds.load()
+
+    adjusted_ds = adjust_quantiledeltamapping(
         simulation=sim_ds,
-        qdm=qdm_ds,
-        year=year,
         variable=variable,
-        include_quantiles=include_quantiles,
+        qdm=qdm_ds,
+        years=years,
+        astype=sim_ds[variable].dtype,
+        include_quantiles=True,
     )
 
-    # Write to NetCDF, usually on local disk, pooling and "fanning-in" NetCDFs is
-    # currently faster and more reliable than Zarr Stores. This logic is handled
-    # in workflow and cloud artifact repository.
-    logger.debug(f"Writing to {out}")
-    adjusted_ds.to_netcdf(out, compute=True)
-    logger.info(f"Written {out}")
+    storage.write(out, adjusted_ds, region=out_zarr_region)
 
 
 @log_service
@@ -210,6 +303,8 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
     ----------
     simulation : str
         fsspec-compatible URL containing simulation data to be adjusted.
+        Dataset must have `variable` as well as a variable, "sim_q", giving
+        the quantiles from QDM bias-correction.
     aiqpd : str
         fsspec-compatible URL pointing to Zarr Store containing canned
         ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling`` Dataset.
@@ -222,6 +317,8 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
     """
     sim_ds = storage.read(simulation)
     aiqpd_ds = storage.read(aiqpd)
+
+    sim_ds = sim_ds.set_coords(["sim_q"])
 
     # needs to not be chunked
     sim_ds = sim_ds.load()

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -27,7 +27,7 @@ def log_service(func):
     @wraps(func)
     def service_logger(*args, **kwargs):
         servicename = func.__name__
-        logger.info(f"Starting {servicename} dodola service")
+        logger.info(f"Starting dodola service {servicename} with {args=}, {kwargs=})")
         func(*args, **kwargs)
         logger.info(f"dodola service {servicename} done")
 
@@ -95,7 +95,7 @@ def prime_qdm_output_zarrstore(simulation, variable, years, out, zarr_region_dim
             variables_to_append.append(variable_name)
 
     if variables_to_append:
-        logger.debug(f"Appending {variables_to_append=} to primed Zarr Store")
+        logger.info(f"Appending {variables_to_append} to primed Zarr Store")
         primer[variables_to_append].to_zarr(
             out, mode="a", compute=True, consolidated=True, safe_chunks=False
         )
@@ -141,12 +141,12 @@ def train_qdm(
         raise ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
 
     if sel_slice:
-        logger.debug(f"Slicing by {sel_slice=}")
+        logger.info(f"Slicing by {sel_slice=}")
         hist = hist.sel(sel_slice)
         ref = ref.sel(sel_slice)
 
     if isel_slice:
-        logger.debug(f"Slicing by {isel_slice=}")
+        logger.info(f"Slicing by {isel_slice=}")
         hist = hist.isel(isel_slice)
         ref = ref.isel(isel_slice)
 
@@ -203,11 +203,11 @@ def apply_qdm(
     qdm_ds = storage.read(qdm)
 
     if sel_slice:
-        logger.debug(f"Slicing by {sel_slice=}")
+        logger.info(f"Slicing by {sel_slice=}")
         sim_ds = sim_ds.sel(sel_slice)
 
     if isel_slice:
-        logger.debug(f"Slicing by {isel_slice=}")
+        logger.info(f"Slicing by {isel_slice=}")
         sim_ds = sim_ds.isel(isel_slice)
 
     variable = str(variable)
@@ -270,12 +270,12 @@ def train_aiqpd(
         raise ValueError(f"kind must be {set(kind_map.keys())}, got {kind}")
 
     if sel_slice:
-        logger.debug(f"Slicing by {sel_slice=}")
+        logger.info(f"Slicing by {sel_slice=}")
         ref_coarse = ref_coarse.sel(sel_slice)
         ref_fine = ref_fine.sel(sel_slice)
 
     if isel_slice:
-        logger.debug(f"Slicing by {isel_slice=}")
+        logger.info(f"Slicing by {isel_slice=}")
         ref_coarse = ref_coarse.isel(isel_slice)
         ref_fine = ref_fine.isel(isel_slice)
 

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -18,6 +18,7 @@ import dodola.services
         "train-aiqpd",
         "apply-aiqpd",
         "validate-dataset",
+        "prime-qdm-output-zarrstore"
     ],
     ids=(
         "--help",
@@ -31,6 +32,7 @@ import dodola.services
         "train-aiqpd --help",
         "apply-aiqpd --help",
         "validate-dataset --help",
+        "prime-qdm-output-zarrstore --help"
     ),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -18,7 +18,7 @@ import dodola.services
         "train-aiqpd",
         "apply-aiqpd",
         "validate-dataset",
-        "prime-qdm-output-zarrstore"
+        "prime-qdm-output-zarrstore",
     ],
     ids=(
         "--help",
@@ -32,7 +32,7 @@ import dodola.services
         "train-aiqpd --help",
         "apply-aiqpd --help",
         "validate-dataset --help",
-        "prime-qdm-output-zarrstore --help"
+        "prime-qdm-output-zarrstore --help",
     ),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -224,7 +224,6 @@ def test_prime_qdm_regional_apply():
     the vanilla and regional approaches.
     """
     # Setup input data.
-    quantile_variable = "sim_q"
     target_variable = "fakevariable"
     variable_kind = "additive"
     n_histdays = 10 * 365  # 10 years of daily historical.

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -213,7 +213,6 @@ def test_prime_qdm_output_zarrstore():
     assert primed_ds[quantile_variable].attrs == adjusted_ds[quantile_variable].attrs
 
 
-
 def test_prime_qdm_regional_apply():
     """
     Integration test checking that prime_qdm_output_zarrstore and apply_qdm can write regionally.
@@ -242,10 +241,11 @@ def test_prime_qdm_regional_apply():
     # modify the data factories to get this. Gives us a way to test regional
     # writes.
     sim = xr.concat([sim, sim.assign({"lat": np.array([2.0])})], dim="lat")
-    sim[target_variable][:,:,-1] += 1  # Introducing a slight difference for different lat.
+    sim[target_variable][
+        :, :, -1
+    ] += 1  # Introducing a slight difference for different lat.
     ref = xr.concat([ref, ref.assign({"lat": np.array([2.0])})], dim="lat")
     hist = xr.concat([hist, hist.assign({"lat": np.array([2.0])})], dim="lat")
-
 
     # Datafactory appends cruft "index" coordinate. We're removing it because we
     # dont need it and I'm too lazy to tinker with input data fixtures.
@@ -299,7 +299,7 @@ def test_prime_qdm_regional_apply():
         variable=target_variable,
         out=primed_url,
         isel_slice=region_1,
-        out_zarr_region=region_1
+        out_zarr_region=region_1,
     )
     region_2 = {"lat": slice(1, 2)}
     train_qdm(
@@ -317,7 +317,7 @@ def test_prime_qdm_regional_apply():
         variable=target_variable,
         out=primed_url,
         isel_slice=region_2,
-        out_zarr_region=region_2
+        out_zarr_region=region_2,
     )
     primed_adjusted_ds = repository.read(primed_url)
 


### PR DESCRIPTION
This PR rewrites the QDM command prototypes, breaking backward compatibility.

Changes include:

- New command for priming a Zarr Store so it can be written to regionally by independent processes. For example:

```bash
dodola prime-qdm-output-zarrstore \
  --simulation "gs://path/to/file/we/want/to/biascorrect.zarr" \
  --variable "tasmax" \
  --years "2015,2100" \
  --out "gs://path/to/where/we/want/biascorrected/to/go.zarr" \
  --zarr-region-dims "lat"
```
We should then be set to write output to that zarr store, regionally, with regions delimited along the "lat" dimension.

- Write to regions of a primed Zarr Store aggressively with `dodola apply-qdm --out-zarr-region`. For example, `--out-zarr-region "lat=0,2"` will write QDM-adjusted output to `slice(0, 2)` along the "lat" dimension. Note this is written aggressively (with `mode="a"`), so use caution not to corrupt existing data. Use this with the  `--selslice` and `--iselslice` arguments to filter input data.

- `dodola apply-qdm` now expects to be applied to multiple years, rather than single years. It does this through a `--years` argument. It's used like `--years=2015,2100`. This should help work run faster and more efficiently on spatially regional subsets consuming the entire input time series.

- Root and variable attributes are now copied from input data to output QDM-adjusted datasets. QDM output should now also match the dtype of the input dataset variable.

- QDM's `sim_q` are now output as a variable instead of a coordinate. These are now output by default.

- `apply-qdm` and `prime-qdm-output-zarrstore` both accept one or more `--new-attrs` options.  This is a fast way of adding simple metadata to output. Each of these take `key=value` pairs that are merged into the output Dataset's root `attrs` before being written.

- Logging is slightly more chatty on INFO, especially with respect to data slicing.