### PR TITLE
Add AIQPD output Zarr priming, slicing, region writing, metadata, multi-year processing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Add AIQPD output Zarr priming (``prime-aipqd-output-zarrstore``), input slicing, region writing, attrs merging, and multi-year processing. This breaks backwards compatibility for ``apply-aiqpd`` and its services and core functions. See the pull request for additional details. (@brews)
+* Add AIQPD output Zarr priming (``prime-aipqd-output-zarrstore``), input slicing, region writing, attrs merging, and multi-year processing. This breaks backwards compatibility for ``apply-aiqpd`` and its services and core functions. See the pull request for additional details. (PR #130, @brews)
 * Similarly, add QDM output Zarr priming (``prime-qdm-output-zarrstore``), region writing, attrs merging, and multi-year processing. This breaks backwards compatibility for ``apply-qdm`` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
 * Make logging slightly more chatty by default. (PR #129, @brews)
 * Add pre-training slicing options to ``train-qdm`` and ``train-aiqpd``. (PR #123, PR #128, @brews)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Add QDM output Zarr priming (``prime-qdm-output-zarrstore``), region writing, attrs merging, and multi-year processing. This breaks backwards compatibility for ``apply-qdm`` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
+* Add AIQPD output Zarr priming (``prime-aipqd-output-zarrstore``), input slicing, region writing, attrs merging, and multi-year processing. This breaks backwards compatibility for ``apply-aiqpd`` and its services and core functions. See the pull request for additional details. (@brews)
+* Similarly, add QDM output Zarr priming (``prime-qdm-output-zarrstore``), region writing, attrs merging, and multi-year processing. This breaks backwards compatibility for ``apply-qdm`` and its services and core functions. See the pull request for additional details. (PR #129, @brews)
 * Make logging slightly more chatty by default. (PR #129, @brews)
 * Add pre-training slicing options to ``train-qdm`` and ``train-aiqpd``. (PR #123, PR #128, @brews)
 * Quick fix validation reading entire zarr store for check. (PR #124, @brews)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -84,6 +84,45 @@ def prime_qdm_output_zarrstore(
     )
 
 
+@dodola_cli.command(help="Prime a Zarr Store for regionally-written AIQPD output")
+@click.option(
+    "--simulation", "-s", required=True, help="URL to simulation store to adjust"
+)
+@click.option("--variable", "-v", required=True, help="Variable name in data stores")
+@click.option(
+    "--out",
+    "-o",
+    required=True,
+    help="URL to write Zarr Store with adjusted simulation year to",
+)
+@click.option(
+    "--zarr-region-dims",
+    required=True,
+    help="'variable1,variable2' comma-delimited list of variables used to define region when writing",
+)
+@click.option(
+    "--new-attrs",
+    multiple=True,
+    help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
+)
+def prime_aiqpd_output_zarrstore(
+    simulation, variable, out, zarr_region_dims=None, new_attrs=None
+):
+    """Initialize a Zarr Store for writing AIQPD output regionally in independent processes"""
+    unpacked_attrs = None
+    if new_attrs:
+        unpacked_attrs = {k: v for x in new_attrs for k, v in (x.split("="),)}
+
+    region_dims = zarr_region_dims.split(",")
+    services.prime_aiqpd_output_zarrstore(
+        simulation=simulation,
+        variable=variable,
+        out=out,
+        zarr_region_dims=region_dims,
+        new_attrs=unpacked_attrs,
+    )
+
+
 @dodola_cli.command(help="Adjust simulation year with quantile delta mapping (QDM)")
 @click.option(
     "--simulation", "-s", required=True, help="URL to simulation store to adjust"

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -261,6 +261,13 @@ def adjust_analogdownscaling(simulation, aiqpd, variable):
 
     out = aiqpd.adjust(simulation[variable])
 
+    out = out.transpose(*simulation[variable].dims)
+    # Overwrite AIQPD output attrs with input simulation attrs.
+    out.attrs = simulation.attrs
+    for k, v in simulation.variables.items():
+        if k in out:
+            out[k].attrs = v.attrs
+
     return out.to_dataset(name=variable)
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -361,7 +361,16 @@ def train_aiqpd(
 
 
 @log_service
-def apply_aiqpd(simulation, aiqpd, variable, out):
+def apply_aiqpd(
+    simulation,
+    aiqpd,
+    variable,
+    out,
+    sel_slice=None,
+    isel_slice=None,
+    out_zarr_region=None,
+    new_attrs=None,
+):
     """Apply AIQPD adjustment factors to downscale a simulation, dump to NetCDF.
 
     Dumping to NetCDF is a feature likely to change in the near future.
@@ -379,11 +388,31 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
         Target variable in `simulation` to downscale. Downscaled output will share the
         same name.
     out : str
-        fsspec-compatible path or URL pointing to NetCDF4 file where the
+        fsspec-compatible path or URL pointing to Zarr Store where the
         AIQPD-downscaled simulation data will be written.
+    sel_slice: dict or None, optional
+        Label-index slice input slimulation dataset before adjusting.
+        A mapping of {variable_name: slice(...)} passed to
+        `xarray.Dataset.sel()`.
+    isel_slice: dict or None, optional
+        Integer-index slice input slimulation dataset before adjusting. A mapping
+        of {variable_name: slice(...)} passed to `xarray.Dataset.isel()`.
+    out_zarr_region: dict or None, optional
+        A mapping of {variable_name: slice(...)} giving the region to write
+        to if outputting to existing Zarr Store.
+    new_attrs : dict or None, optional
+        dict to merge with output Dataset's root ``attrs`` before output.
     """
     sim_ds = storage.read(simulation)
     aiqpd_ds = storage.read(aiqpd)
+
+    if sel_slice:
+        logger.info(f"Slicing by {sel_slice=}")
+        sim_ds = sim_ds.sel(sel_slice)
+
+    if isel_slice:
+        logger.info(f"Slicing by {isel_slice=}")
+        sim_ds = sim_ds.isel(isel_slice)
 
     sim_ds = sim_ds.set_coords(["sim_q"])
 
@@ -393,16 +422,14 @@ def apply_aiqpd(simulation, aiqpd, variable, out):
 
     variable = str(variable)
 
-    downscaled_ds = adjust_analogdownscaling(
+    adjusted_ds = adjust_analogdownscaling(
         simulation=sim_ds, aiqpd=aiqpd_ds, variable=variable
     )
 
-    # Write to NetCDF, usually on local disk, pooling and "fanning-in" NetCDFs is
-    # currently faster and more reliable than Zarr Stores. This logic is handled
-    # in workflow and cloud artifact repository.
-    logger.debug(f"Writing to {out}")
-    downscaled_ds.to_netcdf(out, compute=True, engine="netcdf4")
-    logger.info(f"Written {out}")
+    if new_attrs:
+        adjusted_ds.attrs |= new_attrs
+
+    storage.write(out, adjusted_ds, region=out_zarr_region)
 
 
 @log_service

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -19,7 +19,7 @@ import dodola.services
         "apply-aiqpd",
         "validate-dataset",
         "prime-qdm-output-zarrstore",
-        "prime-aiqpd-output-zarrstore"
+        "prime-aiqpd-output-zarrstore",
     ],
     ids=(
         "--help",
@@ -34,7 +34,7 @@ import dodola.services
         "apply-aiqpd --help",
         "validate-dataset --help",
         "prime-qdm-output-zarrstore --help",
-        "prime-aipqd-output-zarrstore --help"
+        "prime-aipqd-output-zarrstore --help",
     ),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -19,6 +19,7 @@ import dodola.services
         "apply-aiqpd",
         "validate-dataset",
         "prime-qdm-output-zarrstore",
+        "prime-aiqpd-output-zarrstore"
     ],
     ids=(
         "--help",
@@ -33,6 +34,7 @@ import dodola.services
         "apply-aiqpd --help",
         "validate-dataset --help",
         "prime-qdm-output-zarrstore --help",
+        "prime-aipqd-output-zarrstore --help"
     ),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -1160,16 +1160,16 @@ def test_aiqpd_integration(tmpdir, monkeypatch, kind):
     aiqpd_afs_url = "memory://test_aiqpd_downscaling/a/aiqpd_afs/path.zarr"
 
     # Writes NC to local disk, so diff format here:
-    sim_downscaled_key = tmpdir.join("sim_downscaled.nc")
+    sim_downscaled_url = "memory://test_aiqpd_downscaling/a/aiqpd_afs/downscaled.zarr"
 
     # now train AIQPD model
     train_aiqpd(ref_coarse_url, ref_fine_url, aiqpd_afs_url, variable, kind)
 
     # downscale
-    apply_aiqpd(biascorrected_url, aiqpd_afs_url, variable, sim_downscaled_key)
+    apply_aiqpd(biascorrected_url, aiqpd_afs_url, variable, sim_downscaled_url)
 
     # check output
-    downscaled_ds = xr.open_dataset(str(sim_downscaled_key))
+    downscaled_ds = repository.read(sim_downscaled_url)
 
     # check that downscaled average equals bias corrected value
     bc_timestep = biascorrected_fine[variable].isel(time=100).values[0][0]

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -1049,11 +1049,8 @@ def test_train_aiqpd_sel_slice():
 
 
 @pytest.mark.parametrize("kind", ["multiplicative", "additive"])
-def test_aiqpd_integration(tmpdir, monkeypatch, kind):
+def test_aiqpd_integration(kind):
     """Integration test of the QDM and AIQPD services"""
-    monkeypatch.setenv(
-        "HDF5_USE_FILE_LOCKING", "FALSE"
-    )  # Avoid thread lock conflicts with dask scheduler
     lon = [-99.83, -99.32, -99.79, -99.23]
     lat = [42.25, 42.21, 42.63, 42.59]
     time = xr.cftime_range(start="1994-12-17", end="2015-01-15", calendar="noleap")


### PR DESCRIPTION
Sibling to #129 but for priming AIQPD and `apply-aiqpd`. See #129 for details.

This is breaks backward compatibility.