### PR TITLE
Add `dodola get-attrs` command

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Add `dodola get-attrs` command. (@brews)
+* Add `dodola get-attrs` command. (PR #133, @brews)
 * Upgrade Docker base image to ``continuumio/miniconda3:4.10.3``. (PR #132, @brews)
 
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
+* Add `dodola get-attrs` command. (@brews)
 * Upgrade Docker base image to ``continuumio/miniconda3:4.10.3``. (PR #132, @brews)
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -444,6 +444,14 @@ def removeleapdays(x, out):
     services.remove_leapdays(x, out)
 
 
+@dodola_cli.command(help="Get attrs from data")
+@click.argument("x", required=True)
+@click.option("--variable", "-v", help="Variable name in data stores")
+def get_attrs(x, variable=None):
+    """Get JSON str of data attrs metadata."""
+    click.echo(services.get_attrs(x, variable))
+
+
 @dodola_cli.command(help="Bias-correct GCM on observations")
 @click.argument("x", required=True)
 @click.argument("xtrain", required=True)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -1,6 +1,7 @@
 """Used by the CLI or any UI to deliver services to our lovely users
 """
 from functools import wraps
+import json
 import logging
 from dodola.core import (
     apply_bias_correction,
@@ -430,6 +431,14 @@ def apply_qplad(
         adjusted_ds.attrs |= new_attrs
 
     storage.write(out, adjusted_ds, region=out_zarr_region)
+
+
+def get_attrs(x, variable=None):
+    """Get JSON str of `x` attrs metadata."""
+    d = storage.read(x)
+    if variable:
+        d = d[variable]
+    return json.dumps(d.attrs)
 
 
 @log_service

--- a/dodola/tests/test_cli.py
+++ b/dodola/tests/test_cli.py
@@ -20,6 +20,7 @@ import dodola.services
         "validate-dataset",
         "prime-qdm-output-zarrstore",
         "prime-qplad-output-zarrstore",
+        "get-attrs",
     ],
     ids=(
         "--help",
@@ -35,6 +36,7 @@ import dodola.services
         "validate-dataset --help",
         "prime-qdm-output-zarrstore --help",
         "prime-aipqd-output-zarrstore --help",
+        "get-attrs --help",
     ),
 )
 def test_cli_helpflags(subcmd):

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -23,6 +23,7 @@ from dodola.services import (
     train_qplad,
     apply_qplad,
     validate,
+    get_attrs,
 )
 import dodola.repository as repository
 
@@ -1320,3 +1321,24 @@ def test_validation(variable, data_type, time_period):
     repository.write(in_url, ds)
 
     validate(in_url, variable, data_type, time_period)
+
+
+def test_get_attrs_global():
+    """Test that services.get_attrs returns json of global attrs"""
+    url = "memory://test_get_attrs_global/x.zarr"
+    repository.write(url, xr.Dataset({"bar": "SPAM"}, attrs={"fish": "chips"}))
+    out = get_attrs(url)
+    assert out == '{"fish": "chips"}'
+
+
+def test_get_attrs_variable():
+    """Test that services.get_attrs returns json of variable attrs"""
+    url = "memory://test_get_attrs/x.zarr"
+    variable_name = "bar"
+    ds_in = xr.Dataset({variable_name: "SPAM"}, attrs={"fish": "chips"})
+    ds_in[variable_name].attrs["carrot"] = "sticks"
+
+    repository.write(url, ds_in)
+    out = get_attrs(url, variable=variable_name)
+
+    assert out == '{"carrot": "sticks"}'


### PR DESCRIPTION
Adds a `dodola get-attrs` command with tests and services.

Used like:

```bash
dodola get-attrs gs://path/to/store.zarr
```

will give a JSON str of the zarr stores global attrs in STDOUT.

```bash
dodola get-attrs gs://path/to/store.zarr --variable tasmax
```

will fetch the attrs for the "tasmax" variable.
