### PR TITLE
Add qdm, qplad option to set root attrs from json

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
+* Add `--root-attrs-json-file` to `prime-qplad-output-zarrstore`, `apply-qplad`, `prime-qdm-output-zarrstore`, `apply-qdm`. (@brews)
 * Add `dodola get-attrs` command. (PR #133, @brews)
 * Upgrade Docker base image to ``continuumio/miniconda3:4.10.3``. (PR #132, @brews)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
-* Add `--root-attrs-json-file` to `prime-qplad-output-zarrstore`, `apply-qplad`, `prime-qdm-output-zarrstore`, `apply-qdm`. (@brews)
+* Add `--root-attrs-json-file` to `prime-qplad-output-zarrstore`, `apply-qplad`, `prime-qdm-output-zarrstore`, `apply-qdm`. (PR #134, @brews)
 * Add `dodola get-attrs` command. (PR #133, @brews)
 * Upgrade Docker base image to ``continuumio/miniconda3:4.10.3``. (PR #132, @brews)
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -59,12 +59,22 @@ def dodola_cli(debug):
     help="'variable1,variable2' comma-delimited list of variables used to define region when writing",
 )
 @click.option(
+    "--root-attrs-json-file",
+    help="fsspec-compatible URL pointing to a JSON file to use as root ``attrs`` for output data.",
+)
+@click.option(
     "--new-attrs",
     multiple=True,
     help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
 )
 def prime_qdm_output_zarrstore(
-    simulation, variable, years, out, zarr_region_dims=None, new_attrs=None
+    simulation,
+    variable,
+    years,
+    out,
+    zarr_region_dims=None,
+    root_attrs_json_file=None,
+    new_attrs=None,
 ):
     """Initialize a Zarr Store for writing QDM output regionally in independent processes"""
     first_year, last_year = (int(x) for x in years.split(","))
@@ -80,6 +90,7 @@ def prime_qdm_output_zarrstore(
         variable=variable,
         out=out,
         zarr_region_dims=region_dims,
+        root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
     )
 
@@ -101,12 +112,21 @@ def prime_qdm_output_zarrstore(
     help="'variable1,variable2' comma-delimited list of variables used to define region when writing",
 )
 @click.option(
+    "--root-attrs-json-file",
+    help="fsspec-compatible URL pointing to a JSON file to use as root ``attrs`` for output data.",
+)
+@click.option(
     "--new-attrs",
     multiple=True,
     help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
 )
 def prime_qplad_output_zarrstore(
-    simulation, variable, out, zarr_region_dims=None, new_attrs=None
+    simulation,
+    variable,
+    out,
+    zarr_region_dims=None,
+    root_attrs_json_file=None,
+    new_attrs=None,
 ):
     """Initialize a Zarr Store for writing QPLAD output regionally in independent processes"""
     unpacked_attrs = None
@@ -119,6 +139,7 @@ def prime_qplad_output_zarrstore(
         variable=variable,
         out=out,
         zarr_region_dims=region_dims,
+        root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
     )
 
@@ -159,6 +180,10 @@ def prime_qplad_output_zarrstore(
     help="variable=start,stop index to write output to region of existing Zarr Store",
 )
 @click.option(
+    "--root-attrs-json-file",
+    help="fsspec-compatible URL pointing to a JSON file to use as root ``attrs`` for output data.",
+)
+@click.option(
     "--new-attrs",
     multiple=True,
     help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
@@ -172,6 +197,7 @@ def apply_qdm(
     selslice=None,
     iselslice=None,
     out_zarr_region=None,
+    root_attrs_json_file=None,
     new_attrs=None,
 ):
     """Adjust simulation years with QDM bias correction method, outputting Zarr Store"""
@@ -213,6 +239,7 @@ def apply_qdm(
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
         out_zarr_region=out_zarr_region_d,
+        root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
     )
 
@@ -311,6 +338,10 @@ def train_qdm(
     help="variable=start,stop index to write output to region of existing Zarr Store",
 )
 @click.option(
+    "--root-attrs-json-file",
+    help="fsspec-compatible URL pointing to a JSON file to use as root ``attrs`` for output data.",
+)
+@click.option(
     "--new-attrs",
     multiple=True,
     help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
@@ -323,6 +354,7 @@ def apply_qplad(
     selslice=None,
     iselslice=None,
     out_zarr_region=None,
+    root_attrs_json_file=None,
     new_attrs=None,
 ):
     """Adjust simulation with QPLAD downscaling method, outputting Zarr Store"""
@@ -359,6 +391,7 @@ def apply_qplad(
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
         out_zarr_region=out_zarr_region_d,
+        root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
     )
 

--- a/dodola/repository.py
+++ b/dodola/repository.py
@@ -1,7 +1,9 @@
 """Objects to read and write stored climate model data.
 """
 
+import json
 import logging
+import fsspec
 from xarray import open_zarr
 
 
@@ -68,3 +70,15 @@ def write(url_or_path, x, region=None):
     else:
         x.to_zarr(url_or_path, mode="w", compute=True)
     logger.info(f"Written {url_or_path}")
+
+
+def read_attrs(urlpath):
+    """Read and deserialize JSON attrs file"""
+    logger.debug(f"Reading attrs from {urlpath}")
+
+    with fsspec.open(urlpath) as f:
+        out = json.load(f)
+        logger.info(f"Read attrs from {urlpath}")
+
+    logger.debug(f"Read attrs {out}")
+    return out

--- a/dodola/tests/test_repository.py
+++ b/dodola/tests/test_repository.py
@@ -1,3 +1,5 @@
+import json
+import fsspec
 from xarray import Dataset, open_zarr
 import dodola.repository
 
@@ -14,3 +16,15 @@ def test_memory_repository_write():
     url = "memory://test_memory_repository_write.zarr"
     dodola.repository.write(url, Dataset({"bar": "SPAM"}))
     assert open_zarr(url) == Dataset({"bar": "SPAM"})
+
+
+def test_read_attrs():
+    """Basic test that read_attrs reads and deserializes JSON"""
+    url = "memory://test_read_attrs.json"
+    payload = {"foo": "bar"}
+    with fsspec.open(url, mode="w") as fl:
+        json.dump(payload, fl)
+
+    victim = dodola.repository.read_attrs(url)
+
+    assert victim == payload


### PR DESCRIPTION
Add `--root-attrs-json-file` option to let users specify an ffsspec-style URL to a JSON file when can be read and used for the output data's root attrs as an alternative to the input files attrs. 

This will make it easier for users who want to overhaul a rediculous amount of common metadata across multiple steps.

This option was added for commands:

- `prime-qplad-output-zarrstore`
- `apply-qplad`
- `prime-qdm-output-zarrstore`
- `apply-qdm`

`--new-attrs` are applied _after_ JSON attrs are read in and used.