### PR TITLE
Fix attrs missing from services.apply_qplad output Datasets

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.X.X (XXXX-XX-XX)
 ------------------
+* Fix attrs missing from services.apply_qplad output Datasets. (#135, @brews)
 * Add `--root-attrs-json-file` to `prime-qplad-output-zarrstore`, `apply-qplad`, `prime-qdm-output-zarrstore`, `apply-qdm`. (PR #134, @brews)
 * Add `dodola get-attrs` command. (PR #133, @brews)
 * Upgrade Docker base image to ``continuumio/miniconda3:4.10.3``. (PR #132, @brews)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -259,7 +259,7 @@ def adjust_analogdownscaling(simulation, qplad, variable):
     if isinstance(qplad, xr.Dataset):
         qplad = sdba.adjustment.AnalogQuantilePreservingDownscaling.from_dataset(qplad)
 
-    out = qplad.adjust(simulation[variable])
+    out = qplad.adjust(simulation[variable]).to_dataset(name=variable)
 
     out = out.transpose(*simulation[variable].dims)
     # Overwrite QPLAD output attrs with input simulation attrs.
@@ -268,7 +268,7 @@ def adjust_analogdownscaling(simulation, qplad, variable):
         if k in out:
             out[k].attrs = v.attrs
 
-    return out.to_dataset(name=variable)
+    return out
 
 
 def apply_bias_correction(


### PR DESCRIPTION
Previously, root attrs were missing from dodola.services.apply_qplad output Dataset. This PR fixes the root of the problem, in core.adjust_analogdownscaling, so that it correctly passes input Dataset root attrs to returned output.