### PR TITLE
Update dtr range check max to 70 C

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 0.X.X (XXXX-XX-XX)
 ------------------
 * Add additional tests for `dodola.core.*_analogdownscaling` functions. (PR #136, @dgergel, @brews)
+* Update dtr range check max to allow up to 70 C. (PR #138, @brews, @dgergel)
 
 
 0.9.0 (2021-11-15)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -691,7 +691,7 @@ def _test_dtr_range(ds, var):
     Ensure DTR values are in a valid range
     """
     assert (ds[var].min() > 0) and (
-        ds[var].max() < 45
+        ds[var].max() < 70
     ), "diurnal temperature range values are invalid"
 
 


### PR DESCRIPTION
This PR bumps the dtr validation to accept ranges to accept dtr values up to 70 degrees C. This is up from 40 degrees. It's based on ranges we found in a preliminary survey of CMIP6 GCMs.