### PR TITLE
click wetday correction

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,11 +4,6 @@ History
 
 0.XX.X (XXXX-XX-XX)
 -------------------
-*
-
-
-0.11.0 (2021-11-26)
--------------------
 * Add post wet day correction option in CLI dodola (PR #141 @emileten)
 
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,11 +2,14 @@
 History
 =======
 
-
 0.XX.X (XXXX-XX-XX)
 -------------------
 *
 
+
+0.11.0 (2021-11-26)
+-------------------
+* Add post wet day correction option in CLI dodola (PR #141 @emileten)
 
 
 0.10.0 (2021-11-22)
@@ -36,7 +39,7 @@ History
 0.7.0 (2021-11-02)
 ------------------
 * Update xclim version to 0.30.1, this updates the Train/Adjust API for QDM and AIQPD and requires units attributes for all QDM and AIQPD inputs. (PR #119, @dgergel)
-* Add global validation, includes new service ``validate`` for validating cleaned CMIP6, bias corrected and downscaled data for historical and future time periods. (PR #118, @dgergel) 
+* Add global validation, includes new service ``validate`` for validating cleaned CMIP6, bias corrected and downscaled data for historical and future time periods. (PR #118, @dgergel)
 * Regrid copies input Dataset ``attrs`` metadata to output (#116). (PR #121, @brews)
 * Upgrade ``dask`` to 2021.10.0 to cover https://nvd.nist.gov/vuln/detail/CVE-2021-42343. (PR #122, @brews)
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -362,7 +362,7 @@ def apply_qplad(
     out_zarr_region=None,
     root_attrs_json_file=None,
     new_attrs=None,
-    wet_day_post_correction=False,
+    wetday_post_correction=False,
 ):
     """Adjust simulation with QPLAD downscaling method, outputting Zarr Store"""
     unpacked_attrs = None

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -348,7 +348,7 @@ def train_qdm(
 )
 @click.option(
     "--wet-day-post-correction",
-    type=bool
+    type=bool,
     default=False,
     help="Whether to apply wet day frequency correction on downscaled data",
 )

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -349,7 +349,7 @@ def train_qdm(
 @click.option(
     "--wet-day-post-correction/--no-wet-day-post-correction",
     default=False,
-    help="Whether to apply wet day frequency correction on downscaled data"
+    help="Whether to apply wet day frequency correction on downscaled data",
 )
 def apply_qplad(
     simulation,
@@ -361,7 +361,7 @@ def apply_qplad(
     out_zarr_region=None,
     root_attrs_json_file=None,
     new_attrs=None,
-    wet_day_post_correction=False
+    wet_day_post_correction=False,
 ):
     """Adjust simulation with QPLAD downscaling method, outputting Zarr Store"""
     unpacked_attrs = None
@@ -399,7 +399,7 @@ def apply_qplad(
         out_zarr_region=out_zarr_region_d,
         root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
-        wet_day_post_correction=wet_day_post_correction
+        wet_day_post_correction=wet_day_post_correction,
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -346,6 +346,11 @@ def train_qdm(
     multiple=True,
     help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
 )
+@click.option(
+    "--wet-day-post-correction/--no-wet-day-post-correction",
+    default=False,
+    help="Whether to apply wet day frequency correction on downscaled data"
+)
 def apply_qplad(
     simulation,
     qplad,
@@ -356,6 +361,7 @@ def apply_qplad(
     out_zarr_region=None,
     root_attrs_json_file=None,
     new_attrs=None,
+    wet_day_post_correction=False
 ):
     """Adjust simulation with QPLAD downscaling method, outputting Zarr Store"""
     unpacked_attrs = None
@@ -393,6 +399,7 @@ def apply_qplad(
         out_zarr_region=out_zarr_region_d,
         root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
+        wet_day_post_correction=wet_day_post_correction
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -400,7 +400,7 @@ def apply_qplad(
         out_zarr_region=out_zarr_region_d,
         root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
-        wet_day_post_correction=wet_day_post_correction,
+        wet_day_post_correction=wetday_post_correction,
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -347,7 +347,8 @@ def train_qdm(
     help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
 )
 @click.option(
-    "--wet-day-post-correction/--no-wet-day-post-correction",
+    "--wet-day-post-correction",
+    type=bool
     default=False,
     help="Whether to apply wet day frequency correction on downscaled data",
 )

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -347,7 +347,7 @@ def train_qdm(
     help="'key1=value1' entry to merge into the output Dataset root metadata (attrs)",
 )
 @click.option(
-    "--wet-day-post-correction",
+    "--wetday-post-correction",
     type=bool,
     default=False,
     help="Whether to apply wet day frequency correction on downscaled data",

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -406,7 +406,7 @@ def apply_qplad(
     out_zarr_region=None,
     root_attrs_json_file=None,
     new_attrs=None,
-    wet_day_post_correction=False
+    wet_day_post_correction=False,
 ):
     """Apply QPLAD adjustment factors to downscale a simulation, dump to NetCDF.
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -406,6 +406,7 @@ def apply_qplad(
     out_zarr_region=None,
     root_attrs_json_file=None,
     new_attrs=None,
+    wet_day_post_correction=False
 ):
     """Apply QPLAD adjustment factors to downscale a simulation, dump to NetCDF.
 
@@ -441,6 +442,8 @@ def apply_qplad(
         for the output data. ``new_attrs`` will be appended to this.
     new_attrs : dict or None, optional
         dict to merge with output Dataset's root ``attrs`` before output.
+    wet_day_post_correction : bool
+        Whether to apply wet day frequency correction on downscaled data
     """
     sim_ds = storage.read(simulation)
     qplad_ds = storage.read(qplad)
@@ -468,6 +471,9 @@ def apply_qplad(
     adjusted_ds = adjust_analogdownscaling(
         simulation=sim_ds, qplad=qplad_ds, variable=variable
     )
+
+    if wet_day_post_correction:
+        adjusted_ds = apply_wet_day_frequency_correction(adjusted_ds, "post")
 
     if new_attrs:
         adjusted_ds.attrs |= new_attrs


### PR DESCRIPTION
@brews this is related to https://github.com/ClimateImpactLab/downscaleCMIP6/issues/182. It adds a `--wet-day-post-correction` option to the `click` `apply-qplad` command, which we will then want to use in the `apply-qplad` template. 