### PR TITLE
update temp range max to 360K

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.XX.X (XXXX-XX-XX)
 -------------------
+* Increase validation temperature range max to 360 (PR #142, @dgergel)
 * Distinguish missing from excess timesteps in timesteps validation (PR #140, @emileten)
 * Add post wet day correction option in CLI dodola (PR #141 @emileten)
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -707,7 +707,7 @@ def _test_temp_range(ds, var):
     Ensure temperature values are in a valid range
     """
     assert (ds[var].min() > 150) and (
-        ds[var].max() < 350
+        ds[var].max() < 360
     ), "{} values are invalid".format(var)
 
 


### PR DESCRIPTION
Raising the validation limit for tasmax because a few models have max values that are slightly higher than this (they go up to 355K for MIROC6 ssp585 and 351K for KIOST-ESM). This is _extremely_ high, but I think we want to keep as is for now. 