### PR TITLE
precip units temporary replacement

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.XX.X (XXXX-XX-XX)
 -------------------
-* 
+* Add an option to temporarily replace the target variable units in dodola services and use in CLI dodola for precip (PR #143, @emileten)
 
 
 0.11.0 (2021-11-30)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -472,7 +472,7 @@ def train_qplad(
         kind=kind,
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
-        units_replacement=units_replacement
+        units_replacement=units_replacement,
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -228,7 +228,7 @@ def apply_qdm(
             k, v = s.split("=")
             out_zarr_region_d[k] = slice(*map(int, v.split(",")))
 
-    units_replacement = "mm/day" if variable=="pr" else None
+    units_replacement = "mm/day" if variable == "pr" else None
 
     services.apply_qdm(
         simulation=simulation,
@@ -292,7 +292,7 @@ def train_qdm(
             k, v = s.split("=")
             isel_slices_d[k] = slice(*map(int, v.split(",")))
 
-    units_replacement = "mm/day" if variable=="pr" else None
+    units_replacement = "mm/day" if variable == "pr" else None
 
     services.train_qdm(
         historical=historical,
@@ -396,7 +396,7 @@ def apply_qplad(
             k, v = s.split("=")
             out_zarr_region_d[k] = slice(*map(int, v.split(",")))
 
-    units_replacement = "mm/day" if variable=="pr" else None
+    units_replacement = "mm/day" if variable == "pr" else None
 
     services.apply_qplad(
         simulation=simulation,
@@ -462,7 +462,7 @@ def train_qplad(
             k, v = s.split("=")
             isel_slices_d[k] = slice(*map(int, v.split(",")))
 
-    units_replacement = "mm/day" if variable=="pr" else None
+    units_replacement = "mm/day" if variable == "pr" else None
 
     services.train_qplad(
         coarse_reference=coarse_reference,

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -228,6 +228,8 @@ def apply_qdm(
             k, v = s.split("=")
             out_zarr_region_d[k] = slice(*map(int, v.split(",")))
 
+    units_replacement = "mm/day" if variable=="pr" else None
+
     services.apply_qdm(
         simulation=simulation,
         qdm=qdm,
@@ -241,6 +243,7 @@ def apply_qdm(
         out_zarr_region=out_zarr_region_d,
         root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
+        units_replacement=units_replacement,
     )
 
 
@@ -289,6 +292,8 @@ def train_qdm(
             k, v = s.split("=")
             isel_slices_d[k] = slice(*map(int, v.split(",")))
 
+    units_replacement = "mm/day" if variable=="pr" else None
+
     services.train_qdm(
         historical=historical,
         reference=reference,
@@ -297,6 +302,7 @@ def train_qdm(
         kind=kind,
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
+        units_replacement=units_replacement,
     )
 
 
@@ -390,6 +396,8 @@ def apply_qplad(
             k, v = s.split("=")
             out_zarr_region_d[k] = slice(*map(int, v.split(",")))
 
+    units_replacement = "mm/day" if variable=="pr" else None
+
     services.apply_qplad(
         simulation=simulation,
         qplad=qplad,
@@ -401,6 +409,7 @@ def apply_qplad(
         root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
         wet_day_post_correction=wetday_post_correction,
+        units_replacement=units_replacement,
     )
 
 
@@ -453,6 +462,8 @@ def train_qplad(
             k, v = s.split("=")
             isel_slices_d[k] = slice(*map(int, v.split(",")))
 
+    units_replacement = "mm/day" if variable=="pr" else None
+
     services.train_qplad(
         coarse_reference=coarse_reference,
         fine_reference=fine_reference,
@@ -461,6 +472,7 @@ def train_qplad(
         kind=kind,
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
+        units_replacement=units_replacement
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -228,8 +228,6 @@ def apply_qdm(
             k, v = s.split("=")
             out_zarr_region_d[k] = slice(*map(int, v.split(",")))
 
-    units_replacement = "mm/day" if variable == "pr" else None
-
     services.apply_qdm(
         simulation=simulation,
         qdm=qdm,
@@ -243,7 +241,6 @@ def apply_qdm(
         out_zarr_region=out_zarr_region_d,
         root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
-        units_replacement=units_replacement,
     )
 
 
@@ -292,8 +289,6 @@ def train_qdm(
             k, v = s.split("=")
             isel_slices_d[k] = slice(*map(int, v.split(",")))
 
-    units_replacement = "mm/day" if variable == "pr" else None
-
     services.train_qdm(
         historical=historical,
         reference=reference,
@@ -302,7 +297,6 @@ def train_qdm(
         kind=kind,
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
-        units_replacement=units_replacement,
     )
 
 
@@ -396,8 +390,6 @@ def apply_qplad(
             k, v = s.split("=")
             out_zarr_region_d[k] = slice(*map(int, v.split(",")))
 
-    units_replacement = "mm/day" if variable == "pr" else None
-
     services.apply_qplad(
         simulation=simulation,
         qplad=qplad,
@@ -409,7 +401,6 @@ def apply_qplad(
         root_attrs_json_file=root_attrs_json_file,
         new_attrs=unpacked_attrs,
         wet_day_post_correction=wetday_post_correction,
-        units_replacement=units_replacement,
     )
 
 
@@ -462,8 +453,6 @@ def train_qplad(
             k, v = s.split("=")
             isel_slices_d[k] = slice(*map(int, v.split(",")))
 
-    units_replacement = "mm/day" if variable == "pr" else None
-
     services.train_qplad(
         coarse_reference=coarse_reference,
         fine_reference=fine_reference,
@@ -472,7 +461,6 @@ def train_qplad(
         kind=kind,
         sel_slice=sel_slices_d,
         isel_slice=isel_slices_d,
-        units_replacement=units_replacement,
     )
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -13,6 +13,7 @@ import xarray as xr
 from xclim import sdba, set_options
 from xclim.sdba.utils import equally_spaced_nodes
 from xclim.core.calendar import convert_calendar
+from xclim.core import units as xclim_units
 import xesmf as xe
 
 logger = logging.getLogger(__name__)
@@ -523,6 +524,37 @@ def standardize_gcm(ds, leapday_removal=True):
         ds_out = ds_cleaned
 
     return ds_out
+
+
+def xclim_units_any2pint(ds, var):
+    """
+    Parameters
+    ----------
+    ds : xr.Dataset
+    var : str
+
+    Returns
+    -------
+    xr.Dataset with `var` units str attribute converted to xclim's pint registry format
+    """
+    ds[var].attrs["units"] = str(xclim_units.units2pint(ds[var].attrs["units"]))
+    return ds
+
+
+
+def xclim_units_pint2cf(ds, var):
+    """
+    Parameters
+    ----------
+    ds : xr.Dataset
+    var : str
+
+    Returns
+    -------
+    xr.Dataset with `var` units str attribute converted to CF format
+    """
+    ds[var].attrs["units"] = xclim.core.units.pint2cfunits(xclim.core.units.units2pint(ds[var].attrs["units"]))
+    return ds
 
 
 def xclim_remove_leapdays(ds):

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -541,7 +541,6 @@ def xclim_units_any2pint(ds, var):
     return ds
 
 
-
 def xclim_units_pint2cf(ds, var):
     """
     Parameters
@@ -553,7 +552,9 @@ def xclim_units_pint2cf(ds, var):
     -------
     xr.Dataset with `var` units str attribute converted to CF format
     """
-    ds[var].attrs["units"] = xclim_units.pint2cfunits(xclim_units.units2pint(ds[var].attrs["units"]))
+    ds[var].attrs["units"] = xclim_units.pint2cfunits(
+        xclim_units.units2pint(ds[var].attrs["units"])
+    )
     return ds
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -553,7 +553,7 @@ def xclim_units_pint2cf(ds, var):
     -------
     xr.Dataset with `var` units str attribute converted to CF format
     """
-    ds[var].attrs["units"] = xclim.core.units.pint2cfunits(xclim.core.units.units2pint(ds[var].attrs["units"]))
+    ds[var].attrs["units"] = xclim_units.pint2cfunits(xclim_units.units2pint(ds[var].attrs["units"]))
     return ds
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -195,14 +195,7 @@ def prime_qplad_output_zarrstore(
 
 @log_service
 def train_qdm(
-    historical,
-    reference,
-    out,
-    variable,
-    kind,
-    sel_slice=None,
-    isel_slice=None,
-    units_replacement=None,
+    historical, reference, out, variable, kind, sel_slice=None, isel_slice=None
 ):
     """Train quantile delta mapping and dump to `out`
 
@@ -225,8 +218,6 @@ def train_qdm(
     isel_slice: dict or None, optional
         Integer-index slice hist and ref to subset before training. A mapping
         of {variable_name: slice(...)} passed to `xarray.Dataset.isel()`.
-    units_replacement: str or None, optional
-        temporary replacement of `variable` units attribute during qdm training
     """
     hist = storage.read(historical)
     ref = storage.read(reference)
@@ -248,17 +239,9 @@ def train_qdm(
         hist = hist.isel(isel_slice)
         ref = ref.isel(isel_slice)
 
-    if units_replacement:
-        initial_units = ref[variable].attrs["units"]
-        ref[variable].attrs["units"] = units_replacement
-        hist[variable].attrs["units"] = units_replacement
-
     qdm = train_quantiledeltamapping(
         reference=ref, historical=hist, variable=variable, kind=k
     )
-
-    if units_replacement:
-        qdm.ds[variable].attrs["units"] = initial_units
 
     storage.write(out, qdm.ds)
 
@@ -275,7 +258,6 @@ def apply_qdm(
     out_zarr_region=None,
     root_attrs_json_file=None,
     new_attrs=None,
-    units_replacement=None,
 ):
     """Apply trained QDM to adjust a years in a simulation, write to Zarr Store.
 
@@ -312,8 +294,6 @@ def apply_qdm(
         for the output data. ``new_attrs`` will be appended to this.
     new_attrs : dict or None, optional
         dict to merge with output Dataset's root ``attrs`` before output.
-    units_replacement: str or None, optional
-        temporary replacement of `variable` units attribute during qdm adjustment
     """
     sim_ds = storage.read(simulation)
     qdm_ds = storage.read(qdm)
@@ -335,11 +315,6 @@ def apply_qdm(
     qdm_ds.load()
     sim_ds.load()
 
-    if units_replacement:
-        initial_units = sim_ds[variable].attrs["units"]
-        sim_ds[variable].attrs["units"] = units_replacement
-        qdm_ds[variable].attrs["units"] = units_replacement
-
     adjusted_ds = adjust_quantiledeltamapping(
         simulation=sim_ds,
         variable=variable,
@@ -348,9 +323,6 @@ def apply_qdm(
         astype=sim_ds[variable].dtype,
         include_quantiles=True,
     )
-
-    if units_replacement:
-        adjusted_ds[variable].attrs["units"] = initial_units
 
     if new_attrs:
         adjusted_ds.attrs |= new_attrs
@@ -367,7 +339,6 @@ def train_qplad(
     kind,
     sel_slice=None,
     isel_slice=None,
-    units_replacement=None,
 ):
     """Train Quantile-Preserving, Localized Analogs Downscaling and dump to `out`
 
@@ -390,8 +361,6 @@ def train_qplad(
     isel_slice: dict or None, optional
         Integer-index slice hist and ref to subset before training. A mapping
         of {variable_name: slice(...)} passed to `xarray.Dataset.isel()`.
-    units_replacement: str or None, optional
-        temporary replacement of `variable` units attribute during qplad training
     """
     ref_coarse = storage.read(coarse_reference)
     ref_fine = storage.read(fine_reference)
@@ -417,20 +386,12 @@ def train_qplad(
     ref_coarse.load()
     ref_fine.load()
 
-    if units_replacement:
-        initial_units = ref_coarse[variable].attrs["units"]
-        ref_coarse[variable].attrs["units"] = units_replacement
-        ref_fine[variable].attrs["units"] = units_replacement
-
     qplad = train_analogdownscaling(
         coarse_reference=ref_coarse,
         fine_reference=ref_fine,
         variable=variable,
         kind=k,
     )
-
-    if units_replacement:
-        qplad.ds[variable].attrs["units"] = initial_units
 
     storage.write(out, qplad.ds)
 
@@ -447,7 +408,6 @@ def apply_qplad(
     root_attrs_json_file=None,
     new_attrs=None,
     wet_day_post_correction=False,
-    units_replacement=None,
 ):
     """Apply QPLAD adjustment factors to downscale a simulation, dump to NetCDF.
 
@@ -485,8 +445,6 @@ def apply_qplad(
         dict to merge with output Dataset's root ``attrs`` before output.
     wet_day_post_correction : bool
         Whether to apply wet day frequency correction on downscaled data
-    units_replacement: str or None, optional
-        temporary replacement of `variable` units attribute during qplad adjustment
     """
     sim_ds = storage.read(simulation)
     qplad_ds = storage.read(qplad)
@@ -511,17 +469,9 @@ def apply_qplad(
 
     variable = str(variable)
 
-    if units_replacement:
-        initial_units = sim_ds[variable].attrs["units"]
-        sim_ds[variable].attrs["units"] = units_replacement
-        qplad_ds[variable].attrs["units"] = units_replacement
-
     adjusted_ds = adjust_analogdownscaling(
         simulation=sim_ds, qplad=qplad_ds, variable=variable
     )
-
-    if units_replacement:
-        adjusted_ds[variable].attrs["units"] = initial_units
 
     if wet_day_post_correction:
         adjusted_ds = apply_wet_day_frequency_correction(adjusted_ds, "post")

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -194,7 +194,14 @@ def prime_qplad_output_zarrstore(
 
 @log_service
 def train_qdm(
-    historical, reference, out, variable, kind, sel_slice=None, isel_slice=None, units_replacement=None,
+    historical,
+    reference,
+    out,
+    variable,
+    kind,
+    sel_slice=None,
+    isel_slice=None,
+    units_replacement=None,
 ):
     """Train quantile delta mapping and dump to `out`
 

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -361,6 +361,6 @@ def test_xclim_units_conversion():
         np.ones(1), start_dt="2015-01-01", variable_name="fake_variable", units=initial_unit
     )
     xclim_pint_style = xclim_units_any2pint(cf_style, "fake_variable")
-    assert xclim_pint_style["fake_variable"].attrs["units"]=="millimeter / day"
+    assert xclim_pint_style["fake_variable"].attrs["units"] == "millimeter / day"
     back_to_cf_style = xclim_units_pint2cf(xclim_pint_style, "fake_variable")
-    assert back_to_cf_style["fake_variable"].attrs["units"]==initial_unit
+    assert back_to_cf_style["fake_variable"].attrs["units"] == initial_unit

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -17,7 +17,6 @@ from dodola.core import (
 
 def _timeseriesfactory(
     x, start_dt="1995-01-01", variable_name="fakevariable", calendar="noleap", units="K"
-
 ):
     """Populate xr.Dataset with synthetic data for testing, only has time coords"""
     start_time = str(start_dt)
@@ -359,7 +358,6 @@ def test_qplad_integration_af_quantiles():
     assert (downscaled[variable].values[:, lat_pt]).sum() == 564
 
 
-
 def test_xclim_units_conversion():
 
     initial_unit = "mm d-1"
@@ -373,6 +371,7 @@ def test_xclim_units_conversion():
     assert xclim_pint_style["fake_variable"].attrs["units"] == "millimeter / day"
     back_to_cf_style = xclim_units_pint2cf(xclim_pint_style, "fake_variable")
     assert back_to_cf_style["fake_variable"].attrs["units"] == initial_unit
+
 
 def test_xclim_convert_360day_calendar_interpolate():
 
@@ -436,4 +435,3 @@ def test_xclim_convert_360day_calendar_interpolate():
         xclim_convert_360day_calendar_interpolate(
             ds_fake_360_with_nan, "standard", "random", "linear", True, False
         )  # should fail if pushed to interpolate with pre existing NaN
-

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -14,7 +14,9 @@ from dodola.core import (
 )
 
 
-def _timeseriesfactory(x, start_dt="1995-01-01", variable_name="fakevariable", units="K"):
+def _timeseriesfactory(
+    x, start_dt="1995-01-01", variable_name="fakevariable", units="K"
+):
     """Populate xr.Dataset with synthetic data for testing, only has time coords"""
     start_time = str(start_dt)
     if x.ndim != 1:
@@ -354,11 +356,15 @@ def test_qplad_integration_af_quantiles():
     # check that the adjustment factor did not get applied to any other days of the year
     assert (downscaled[variable].values[:, lat_pt]).sum() == 564
 
+
 def test_xclim_units_conversion():
 
     initial_unit = "mm d-1"
     cf_style = _timeseriesfactory(
-        np.ones(1), start_dt="2015-01-01", variable_name="fake_variable", units=initial_unit
+        np.ones(1),
+        start_dt="2015-01-01",
+        variable_name="fake_variable",
+        units=initial_unit,
     )
     xclim_pint_style = xclim_units_any2pint(cf_style, "fake_variable")
     assert xclim_pint_style["fake_variable"].attrs["units"] == "millimeter / day"


### PR DESCRIPTION
This solves #125, (precip units incompatible with the `xclim` `pint` registry)

1. added an `units_replacement` parameter to each `services.apply-*` and `services.train-*` function, to (optionally) temporarily swap the `variable` `units` attribute for a chosen string, during bias correction and downscaling. 

2. this option is used in each upstream `cli` function if `variable=='pr'` to temporarily swap units with `"mm/day"`. 

@brews (1) is general (variable agnostic) in case we want to make use of that in other cases, but (2) doesn't give an option and uses it for precip -- so that we don't need to change workflow templates _now_. I didn't write a unit test, it sounded like a lot of code to me for what it is. I am not fully aware of our test coverage ambitions though. Let me know. 