### PR TITLE
add dtr correction for small dtr values

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.XX.X (XXXX-XX-XX)
 -------------------
-* 
+* Add diurnal temperature range (DTR) correction for small DTR values below 1 (converts them to 1) (PR #145, @dgergel)
 
 
 0.11.0 (2021-11-30)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -650,6 +650,16 @@ def correct_wetday_frequency(x, out, process):
     services.correct_wet_day_frequency(str(x), out=str(out), process=str(process))
 
 
+@dodola_cli.command(
+    help="Correct small values of diurnal temperature range (DTR) in a dataset"
+)
+@click.argument("x", required=True)
+@click.option("--out", "-o", required=True)
+def correct_dtr(x, out):
+    """Correct small values of diurnal temperature range (DTR) in a dataset"""
+    services.correct_small_dtr(str(x), out=str(out))
+
+
 @dodola_cli.command(help="Validate a CMIP6, bias corrected or downscaled dataset")
 @click.argument("x", required=True)
 @click.option("--variable", "-v", required=True)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -655,9 +655,12 @@ def correct_wetday_frequency(x, out, process):
 )
 @click.argument("x", required=True)
 @click.option("--out", "-o", required=True)
-def correct_dtr(x, out):
+@click.option(
+    "--threshold", "-t", help="Threshold for correcting small DTR values up to"
+)
+def correct_dtr(x, out, threshold=1.0):
     """Correct small values of diurnal temperature range (DTR) in a dataset"""
-    services.correct_small_dtr(str(x), out=str(out))
+    services.correct_small_dtr(str(x), out=str(out), threshold=float(threshold))
 
 
 @dodola_cli.command(help="Validate a CMIP6, bias corrected or downscaled dataset")

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -570,7 +570,7 @@ def apply_wet_day_frequency_correction(ds, process):
     return ds_corrected
 
 
-def apply_small_dtr_correction(ds):
+def apply_small_dtr_correction(ds, threshold):
     """
     Converts all diurnal temperature range (DTR) values below a threshold
     to the threshold value.
@@ -578,13 +578,13 @@ def apply_small_dtr_correction(ds):
     Parameters
     ----------
     ds : xr.Dataset
+    threshold : int or float
 
     Returns
     -------
     xr.Dataset
 
     """
-    threshold = 1.0  # Kelvin
 
     ds_corrected = ds.where(ds >= threshold, threshold)
     return ds_corrected

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -570,6 +570,26 @@ def apply_wet_day_frequency_correction(ds, process):
     return ds_corrected
 
 
+def apply_small_dtr_correction(ds):
+    """
+    Converts all diurnal temperature range (DTR) values below a threshold
+    to the threshold value.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+
+    Returns
+    -------
+    xr.Dataset
+
+    """
+    threshold = 1.0  # Kelvin
+
+    ds_corrected = ds.where(ds >= threshold, threshold)
+    return ds_corrected
+
+
 def validate_dataset(ds, var, data_type, time_period="future"):
     """
     Validate a Dataset. Valid for CMIP6, bias corrected and downscaled.

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -736,7 +736,7 @@ def correct_wet_day_frequency(x, out, process):
 
 
 @log_service
-def correct_small_dtr(x, out):
+def correct_small_dtr(x, out, threshold=1.0):
     """Corrects small diurnal temperature range (DTR) values in a dataset
 
     Parameters
@@ -745,10 +745,11 @@ def correct_small_dtr(x, out):
         Storage URL to input xr.Dataset that will be corrected.
     out : str
         Storage URL to write corrected output to.
-
+    threshold : int or float, optional
+        All DTR values lower than this value are corrected to the threshold value.
     """
     ds = storage.read(x)
-    ds_corrected = apply_small_dtr_correction(ds)
+    ds_corrected = apply_small_dtr_correction(ds, threshold)
     storage.write(out, ds_corrected)
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -16,6 +16,7 @@ from dodola.core import (
     train_analogdownscaling,
     adjust_analogdownscaling,
     validate_dataset,
+    apply_small_dtr_correction,
 )
 import dodola.repository as storage
 
@@ -731,6 +732,23 @@ def correct_wet_day_frequency(x, out, process):
     """
     ds = storage.read(x)
     ds_corrected = apply_wet_day_frequency_correction(ds, process=process)
+    storage.write(out, ds_corrected)
+
+
+@log_service
+def correct_small_dtr(x, out):
+    """Corrects small diurnal temperature range (DTR) values in a dataset
+
+    Parameters
+    ----------
+    x : str
+        Storage URL to input xr.Dataset that will be corrected.
+    out : str
+        Storage URL to write corrected output to.
+
+    """
+    ds = storage.read(x)
+    ds_corrected = apply_small_dtr_correction(ds)
     storage.write(out, ds_corrected)
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -24,6 +24,7 @@ from dodola.services import (
     apply_qplad,
     validate,
     get_attrs,
+    correct_small_dtr,
 )
 import dodola.repository as repository
 
@@ -899,6 +900,29 @@ def test_correct_wet_day_frequency(process):
             .all()
             == 0.0
         )
+
+
+def test_correct_small_dtr():
+    """Test that diurnal temperature range (DTR) correction corrects small values of DTR"""
+    # Make some fake dtr data
+    n = 700
+    threshold = 1.0
+    ts = np.linspace(0.0, 10, num=n)
+    ds_dtr = _datafactory(ts, start_time="1950-01-01")
+    in_url = "memory://test_correct_small_dtr/an/input/path.zarr"
+    out_url = "memory://test_correct_small_dtr/an/output/path.zarr"
+    repository.write(in_url, ds_dtr)
+
+    correct_small_dtr(in_url, out=out_url)
+    ds_dtr_corrected = repository.read(out_url)
+
+    # all values below threshold should have been set to the threshold value
+    assert (
+        ds_dtr_corrected["fakevariable"].where(
+            ds_dtr["fakevariable"] < threshold, drop=True
+        )
+        >= threshold
+    )
 
 
 @pytest.mark.parametrize("kind", ["multiplicative", "additive"])

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -918,9 +918,9 @@ def test_correct_small_dtr():
 
     # all values below threshold should have been set to the threshold value
     assert (
-        ds_dtr_corrected["fakevariable"].where(
-            ds_dtr["fakevariable"] < threshold, drop=True
-        ).all()
+        ds_dtr_corrected["fakevariable"]
+        .where(ds_dtr["fakevariable"] < threshold, drop=True)
+        .all()
         >= threshold
     )
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -920,7 +920,7 @@ def test_correct_small_dtr():
     assert (
         ds_dtr_corrected["fakevariable"].where(
             ds_dtr["fakevariable"] < threshold, drop=True
-        )
+        ).all()
         >= threshold
     )
 


### PR DESCRIPTION
This PR adds a new service for correcting diurnal temperature range values below a threshold. Since this function will only be used for DTR, the threshold is defined within the `core` function and is not an input argument. We can change this later if desired. 

Used as: 

```
dodola correct-dtr /path/to/dtr_to_correct.zarr \
--out /path/to/corrected_dtr.zarr
```

This will then be added to the DTR downscaling workflow and will solve https://github.com/ClimateImpactLab/downscaleCMIP6/issues/380. 