### PR TITLE
Update biascorrection validation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.XX.X (XXXX-XX-XX)
 -------------------
-* 
+* Decrease allowed timesteps for bias corrected/downscaled files in validation to account for models that only go through 2099 (PR #146, @dgergel) 
 
 
 0.11.0 (2021-11-30)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -640,7 +640,7 @@ def _test_timesteps(ds, data_type, time_period):
     for the data_type/time_period combination.
     """
     if time_period == "future":
-        # bias corrected/downscaled data should have 2015 - 2100
+        # bias corrected/downscaled data has 2015 - 2099 or 2100 depending on the model
         # CMIP6 future data has an additional ten years from the historical model run
         if data_type == "cmip6":
             assert (
@@ -656,16 +656,23 @@ def _test_timesteps(ds, data_type, time_period):
                 )
         else:
             assert (
-                len(ds.time) >= 31390
+                len(ds.time) >= 31025  # 2015 - 2099
             ), "projection {} file is missing timesteps, has {}".format(
                 data_type, len(ds.time)
             )
-            if len(ds.time) > 31390:
+            if len(ds.time) > 31390:  # 2015 - 2100
                 warnings.warn(
                     "projection {} file has excess timesteps, has {}".format(
                         data_type, len(ds.time)
                     )
                 )
+            if len(ds.time) < 31390:
+                warnings.warn(
+                    "projection {} file goes through 2099 instead of 2100, has {}".format(
+                        data_type, len(ds.time)
+                    )
+                )
+
     elif time_period == "historical":
         # bias corrected/downscaled data should have 1950 - 2014
         # CMIP6 historical data has an additional ten years from SSP 370 (or 245 if 370 not available)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -666,12 +666,6 @@ def _test_timesteps(ds, data_type, time_period):
                         data_type, len(ds.time)
                     )
                 )
-            if len(ds.time) < 31390:
-                warnings.warn(
-                    "projection {} file goes through 2099 instead of 2100, has {}".format(
-                        data_type, len(ds.time)
-                    )
-                )
 
     elif time_period == "historical":
         # bias corrected/downscaled data should have 1950 - 2014


### PR DESCRIPTION
This PR updates validation of the number of timesteps in a bias corrected or downscaled output file to account for models that end in 2099 versus 2100. 

Addresses the issue with some models https://github.com/ClimateImpactLab/downscaleCMIP6/issues/383