### PR TITLE
exclude poles from DTR nan-checking 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 0.xx.x (xxxx-xx-xx)
 -------------------
 * Add diurnal temperature range (DTR) correction for small DTR values below 1 (converts them to 1) (PR #145, @dgergel)
-
+* Exclude poles from diurnal temperature range (DTR) nan automated validation (PR #147 @emileten)
 
 0.11.1 (2021-12-03)
 -------------------

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -622,7 +622,9 @@ def validate_dataset(ds, var, data_type, time_period="future"):
 
         if v == "dtr":
             logger.info("Checking for NaNs in DTR outside of poles...")
-            _test_for_nans(d.where((d["lat"] < 89.5) & (d["lat"] > -89.5), drop=True), v)
+            _test_for_nans(
+                d.where((d["lat"] < 89.5) & (d["lat"] > -89.5), drop=True), v
+            )
         else:
             _test_for_nans(d, v)
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -620,7 +620,10 @@ def validate_dataset(ds, var, data_type, time_period="future"):
     def memory_intensive_tests(ds, v, t):
         d = ds.sel(time=str(t))
 
-        _test_for_nans(d, v)
+        if v == "dtr":
+            _test_for_nans_dtr(d)
+        else:
+            _test_for_nans(d, v)
 
         if v == "tasmin":
             _test_temp_range(d, v)
@@ -653,6 +656,11 @@ def _test_for_nans(ds, var):
     """
     assert ds[var].isnull().sum() == 0, "there are nans!"
 
+def _test_for_nans_dtr(ds):
+    """
+    Tests for presence of NaNs excluding poles
+    """
+    assert ds.where((ds.lat != 89.5) & (ds.lat != -89.5), drop=True)["dtr"].isnull().sum() == 0, "there are nans!"
 
 def _test_timesteps(ds, data_type, time_period):
     """

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -656,11 +656,16 @@ def _test_for_nans(ds, var):
     """
     assert ds[var].isnull().sum() == 0, "there are nans!"
 
+
 def _test_for_nans_dtr(ds):
     """
     Tests for presence of NaNs excluding poles
     """
-    assert ds.where((ds.lat != 89.5) & (ds.lat != -89.5), drop=True)["dtr"].isnull().sum() == 0, "there are nans!"
+    assert (
+        ds.where((ds.lat != 89.5) & (ds.lat != -89.5), drop=True)["dtr"].isnull().sum()
+        == 0
+    ), "there are nans!"
+
 
 def _test_timesteps(ds, data_type, time_period):
     """

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -621,7 +621,8 @@ def validate_dataset(ds, var, data_type, time_period="future"):
         d = ds.sel(time=str(t))
 
         if v == "dtr":
-            _test_for_nans_dtr(d)
+            logger.info("Checking for NaNs in DTR outside of poles...")
+            _test_for_nans(d.where((d["lat"] < 89.5) & (d["lat"] > -89.5), drop=True), v)
         else:
             _test_for_nans(d, v)
 
@@ -655,16 +656,6 @@ def _test_for_nans(ds, var):
     Tests for presence of NaNs
     """
     assert ds[var].isnull().sum() == 0, "there are nans!"
-
-
-def _test_for_nans_dtr(ds):
-    """
-    Tests for presence of NaNs excluding poles
-    """
-    assert (
-        ds.where((ds.lat != 89.5) & (ds.lat != -89.5), drop=True)["dtr"].isnull().sum()
-        == 0
-    ), "there are nans!"
 
 
 def _test_timesteps(ds, data_type, time_period):


### PR DESCRIPTION
This PR solves downscaleCMIP6 https://github.com/ClimateImpactLab/downscaleCMIP6/issues/379. 

I added a separate `_test_for_nans_dtr` function in the automated validation that excludes the poles (`lat==89.5` and `lat==-89.5`). I chose to filter by label rather than index because I am not sure what happens to indexes with chunked jobs, and label indexing is fast anyways. 

I can test this change by running separately the cleaning-validation DTR workflow step of this workflow that failed ? https://argo.cildc6.org/archived-workflows/default/62e2936b-e039-47fd-8655-cfd134bd4985. Which is DTR `EC-Earth3`. 