### PR TITLE
rechunk along time dim before cal conversion

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.xx.x (xxxx-xx-xx)
 -------------------
+* Rechunk before 360 days calendar conversion (PR #150, @emileten)
 * Add 360 days calendar support (PR #144, @emileten)
 * Add an option to temporarily replace the target variable units in dodola services and use in CLI dodola for precip (PR #143, @emileten)
 * Add diurnal temperature range (DTR) correction for small DTR values below 1 (converts them to 1) (PR #145, @dgergel)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -647,7 +647,7 @@ def xclim_convert_360day_calendar_interpolate(
     )
 
     if interpolation:
-        ds_converted_rechunked = ds_converted.chunk(chunks={'time': -1})
+        ds_converted_rechunked = ds_converted.chunk(chunks={"time": -1})
         ds_out = ds_converted_rechunked.interpolate_na("time", interpolation)
     else:
         ds_out = ds_converted


### PR DESCRIPTION
Solving https://github.com/ClimateImpactLab/dodola/issues/149, from https://github.com/ClimateImpactLab/downscaleCMIP6/issues/436. 

Interpolation along the `time` dimension was impossible because in production our datasets are chunked along `time` in `standardize_gcm`. 

I changed `xclim_convert_360day_calendar_interpolate` so that it gathers the `time` chunks if asked to interpolate. It doesn't re-rechunk after that. `standardize_gcm` does it anyways.

The other option was to `.load()` all the data. My reasoning is that this computation is not large enough to load all that data into memory. But, let me know if my judgment isn't right @brews. 

I manually tested that this solves the issue with the following snippet of code on my local machine. @brews it seemed to me we're not accounting for chunking in any of our automated tests. Did I miss something ? [EDIT] I think I might missed something which would have caught this -- a version of the function in `services`, interacting with `repository` ?

```
import numpy as np
import dask
import xarray as xr
import pytest 

cluster = dask.distributed.LocalCluster()
client = dask.distributed.Client(cluster)

np_da = np.random.rand(1000, 1000)
np_da[100, 100] = np.NaN
xr_da = xr.DataArray(np_da, {'dim1':range(1000), 'dim2':range(1000)}, ['dim1', 'dim2'])
xr_ds = xr.Dataset({'var':xr_da})
xr_ds_chunked = xr_ds.chunk(chunks={'dim1':10, 'dim2':10})
with pytest.raises(ValueError):
	xr_ds_chunked.interpolate_na('dim1')
xr_ds_chunked.load()
xr_ds_rechunked = xr_ds_chunked.chunk(chunks={'dim1':-1})
xr_ds_rechunked_interp = xr_ds_rechunked.interpolate_na('dim1')
```