### PR TITLE
Fix 360 day calendar conversion chunk errors from dodola.services.clean_cmip6

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,12 +5,12 @@ History
 
 0.XX.X (XXXX-XX-XX)
 -------------------
-* 
+* Fix rechunk error when converting 360 days calendars. (#149, PR #151, @brews)
 
 
 0.12.0 (2021-12-09)
 -------------------
-* Add 360 days calendar support. (PR #144, PR #151, @emileten, @brews)
+* Add 360 days calendar support (PR #144, @emileten)
 * Add an option to temporarily replace the target variable units in dodola services and use in CLI dodola for precip (PR #143, @emileten)
 * Add diurnal temperature range (DTR) correction for small DTR values below 1 (converts them to 1) (PR #145, @dgergel)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 
 0.xx.x (xxxx-xx-xx)
 -------------------
-* Add 360 days calendar support (PR #144, @emileten)
+* Add 360 days calendar support. (PR #144, PR #151, @emileten, @brews)
 * Add an option to temporarily replace the target variable units in dodola services and use in CLI dodola for precip (PR #143, @emileten)
 * Add diurnal temperature range (DTR) correction for small DTR values below 1 (converts them to 1) (PR #145, @dgergel)
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -472,6 +472,9 @@ def xesmf_regrid(
 def standardize_gcm(ds, leapday_removal=True):
     """
 
+    360 calendar conversion requires that there are no chunks in
+    the 'time' dimension of `ds`.
+
     Parameters
     ----------
     ds : xr.Dataset

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -725,7 +725,7 @@ def clean_cmip6(x, out, leapday_removal):
     # Cannot have chunks in time dimension for 360 day calendar conversion so loading
     # data into memory.
     ds.load()
-    
+
     cleaned_ds = standardize_gcm(ds, leapday_removal)
     storage.write(out, cleaned_ds)
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -708,6 +708,9 @@ def regrid(
 def clean_cmip6(x, out, leapday_removal):
     """Cleans and standardizes CMIP6 GCM
 
+    This loads the entire `x` Dataset into memory for speed
+    and to avoid chunking errors.
+
     Parameters
     ----------
     x : str
@@ -718,6 +721,11 @@ def clean_cmip6(x, out, leapday_removal):
         Whether or not to remove leap days.
     """
     ds = storage.read(x)
+
+    # Cannot have chunks in time dimension for 360 day calendar conversion so loading
+    # data into memory.
+    ds.load()
+    
     cleaned_ds = standardize_gcm(ds, leapday_removal)
     storage.write(out, cleaned_ds)
 


### PR DESCRIPTION
Solves chunking errors by loading the input Dataset into memory before cleaning/standardizing.

Close #149