### PR TITLE
update DTR validation ranges

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 0.XX.X (XXXX-XX-XX)
 -------------------
+* Update diurnal temperature range (DTR) validation to differentiate polar and non-polar regions. (PR #153, @dgergel)
 * Fix rechunk error when converting 360 days calendars. (#149, PR #151, @brews)
 * Remove cruft code. Removes ``dodola`` commands ``biascorrect``, ``downscale``, ``buildweights`` along with corresponding functions in ``dodola.services`` and ``dodola.core``.  (PR #152, @brews)
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -710,10 +710,25 @@ def _test_temp_range(ds, var):
 def _test_dtr_range(ds, var):
     """
     Ensure DTR values are in a valid range
+    Test polar values separately since some polar values can be much higher post-bias correction.
     """
-    assert (ds[var].min() > 0) and (
-        ds[var].max() < 70
-    ), "diurnal temperature range values are invalid"
+    # test that DTR values are greater than 0
+    assert (
+        ds[var].min() > 0
+    ), "diurnal temperature range values are not greater than zero"
+
+    # test polar DTR values
+    assert (
+        ds[var].where(ds.lat < -60).max() < 100
+    ), "diurnal temperature range values for polar southern latitudes are greater than 100"
+    assert (
+        ds[var].where(ds.lat > 60).max() < 100
+    ), "diurnal temperature range values for polar northern latitudes are greater than 100"
+
+    # test all but polar regions
+    assert (
+        ds[var].where((ds.lat > -60) & (ds.lat < 60)).max() < 70
+    ), "diurnal temperature range values for non-polar regions are greater than 70"
 
 
 def _test_negative_values(ds, var):

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -718,12 +718,21 @@ def _test_dtr_range(ds, var):
     ), "diurnal temperature range values are not greater than zero"
 
     # test polar DTR values
-    assert (
-        ds[var].where(ds.lat < -60).max() < 100
-    ), "diurnal temperature range values for polar southern latitudes are greater than 100"
-    assert (
-        ds[var].where(ds.lat > 60).max() < 100
-    ), "diurnal temperature range values for polar northern latitudes are greater than 100"
+    southern_polar_max = ds[var].where(ds.lat < -60).max()
+    if (southern_polar_max is not None) and (southern_polar_max >= 100):
+        assert (
+            southern_polar_max < 100
+        ), "diurnal temperature range max is {} for polar southern latitudes".format(
+            southern_polar_max
+        )
+
+    northern_polar_max = ds[var].where(ds.lat > 60).max()
+    if (northern_polar_max is not None) and (northern_polar_max >= 100):
+        assert (
+            northern_polar_max < 100
+        ), "diurnal temperature range max is {} for polar northern latitudes".format(
+            northern_polar_max
+        )
 
     # test all but polar regions
     assert (


### PR DESCRIPTION
Differentiates validation of DTR ranges based on polar regions. 

addresses the bug mentioned here: https://github.com/ClimateImpactLab/downscaleCMIP6/issues/450