### PR TITLE
update DTR validation to include data type and different min validati…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ History
 
 0.XX.X (XXXX-XX-XX)
 -------------------
-* Update diurnal temperature range (DTR) validation to differentiate polar and non-polar regions. (PR #153, @dgergel)
+* Update diurnal temperature range (DTR) validation to differentiate min DTR accepted value for CMIP6 vs bias corrected and downscaled data inputs (PR #155, @dgergel)
+* Update diurnal temperature range (DTR) validation to differentiate polar and non-polar regions (PR #153, @dgergel)
 * Fix rechunk error when converting 360 days calendars. (#149, PR #151, @brews)
 * Remove cruft code. Removes ``dodola`` commands ``biascorrect``, ``downscale``, ``buildweights`` along with corresponding functions in ``dodola.services`` and ``dodola.core``.  (PR #152, @brews)
 


### PR DESCRIPTION
This PR updates DTR validation to differentiate bw CMIP6 and bias corrected/downscaled allowed min values. This is because CMIP6 data, before applying the DTR small values "correction", may have zero values if tasmin > tasmax and those have been swapped. 

Also cleaned up a bit of other DTR validation in this one. 

addresses this GFDL DTR run bug: https://github.com/ClimateImpactLab/downscaleCMIP6/issues/452