### PR TITLE
Internal: Add Makefile, use for CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,8 +19,7 @@ jobs:
         pip install flake8 black
     - name: Test code quality
       run: |
-        flake8 --count --show-source --statistics
-        black -v --check dodola/*
+        make format-check
 
   container-tests:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test:
+	pytest -vv
+format:
+	black dodola
+format-check:
+	flake8 --count --show-source --statistics
+	black -v --check dodola


### PR DESCRIPTION
This adds a Makefile. This hopefully make the testing and linting more transparent to contributors who want to run these locally. Use like:

```
make format-check
make test
make format
```

Changes GH Actions workflows so it uses this for code-quality check.