### PR TITLE
Update wdf correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Update wet day frequency correction to include small negative values in correction and to limit the correction range to the threshold * 10 ^ -2. (PR #158, @dgergel)
 - Update package setup, README, HISTORY/CHANGELOG to new system. (PR #154, @brews)
 
 ## [0.13.0] - 2021-12-17

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -535,9 +535,13 @@ def apply_wet_day_frequency_correction(ds, process):
         28, Issue 7, pp. 6938-6959.
     """
     threshold = 0.05  # mm/day
-    low = 1e-16
+    # adjusted "low" value from the original epsilon in Cannon et al 2015 to 
+    # avoid having some values get extremely large 
+    low = threshold * pow(10, -2)
+    
     if process == "pre":
-        ds_corrected = ds.where(ds != 0.0, np.random.uniform(low=low, high=threshold))
+        # includes very small values that are negative in CMIP6 output
+        ds_corrected = ds.where(ds > 0.0, np.random.uniform(low=low, high=threshold))
     elif process == "post":
         ds_corrected = ds.where(ds >= threshold, 0.0)
     else:

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -535,10 +535,10 @@ def apply_wet_day_frequency_correction(ds, process):
         28, Issue 7, pp. 6938-6959.
     """
     threshold = 0.05  # mm/day
-    # adjusted "low" value from the original epsilon in Cannon et al 2015 to 
-    # avoid having some values get extremely large 
+    # adjusted "low" value from the original epsilon in Cannon et al 2015 to
+    # avoid having some values get extremely large
     low = threshold * pow(10, -2)
-    
+
     if process == "pre":
         # includes very small values that are negative in CMIP6 output
         ds_corrected = ds.where(ds > 0.0, np.random.uniform(low=low, high=threshold))
@@ -765,7 +765,8 @@ def _test_negative_values(ds, var):
     Tests for presence of negative values
     """
     # this is not set to 0 to deal with floating point error
-    assert ds[var].where(ds[var] < -0.001).count() == 0, "there are negative values!"
+    neg_values = ds[var].where(ds[var] < -0.001).count()
+    assert neg_values == 0, "there are {} negative values!".format(neg_values)
 
 
 def _test_maximum_precip(ds, var):
@@ -773,6 +774,10 @@ def _test_maximum_precip(ds, var):
     Tests that max precip is reasonable
     """
     threshold = 2000  # in mm, max observed is 1.825m --> maximum occurs between 0.5-0.8
+    max_precip = ds[var].max()
+    num_precip_values_over_threshold = ds[var].where(ds[var] > threshold).count()
     assert (
-        ds[var].where(ds[var] > threshold).count() == 0
-    ), "maximum precip exceeds 2000mm"
+        num_precip_values_over_threshold == 0
+    ), "maximum precip is {} mm and there are {} values over 2000mm".format(
+        max_precip, num_precip_values_over_threshold
+    )

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -749,10 +749,10 @@ def test_correct_wet_day_frequency(process):
     if process == "pre":
         # all 0s and very small negative values should have been set to a random uniform value below 0.05
         corrected_values = ds_precip_corrected["fakevariable"].where(
-                ds_precip["fakevariable"] <= 0, drop=True
-            )
-        assert (corrected_values > 0.0)
-        assert (corrected_values < threshold)
+            ds_precip["fakevariable"] <= 0, drop=True
+        )
+        assert corrected_values > 0.0
+        assert corrected_values < threshold
     elif process == "post":
         # all values below 0.05 should be reset to 0
         assert (

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -747,19 +747,12 @@ def test_correct_wet_day_frequency(process):
     ds_precip_corrected = repository.read(out_url)
 
     if process == "pre":
-        # all 0 values should have been set to a random uniform value below 0.05
-        assert (
-            ds_precip_corrected["fakevariable"].where(
-                ds_precip["fakevariable"] == 0, drop=True
+        # all 0s and very small negative values should have been set to a random uniform value below 0.05
+        corrected_values = ds_precip_corrected["fakevariable"].where(
+                ds_precip["fakevariable"] <= 0, drop=True
             )
-            != 0.0
-        )
-        assert (
-            ds_precip_corrected["fakevariable"].where(
-                ds_precip["fakevariable"] == 0, drop=True
-            )
-            < threshold
-        )
+        assert (corrected_values > 0.0)
+        assert (corrected_values < threshold)
     elif process == "post":
         # all values below 0.05 should be reset to 0
         assert (


### PR DESCRIPTION
Updates the wet day frequency correction to 1) correct very small negative values, 2) limit the "corrected" range to  `threshold*10^-2` to the threshold (which we set to 0.05 mm) to prevent values from blowing up. 

Also updates the precip validation code a bit to be more useful when it fails. 

see https://github.com/ClimateImpactLab/downscaleCMIP6/issues/458 for additional context 