### PR TITLE
update WDF correction with Hempel et al 2013 additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Update wet day frequency correction again to raise the "low" value used to the threshold value / 10 (PR #159, @dgergel)
+- Update wet day frequency correction to incorporate method additions from Hempel et al 2013. (PR #162, @dgergel)
+- Update wet day frequency correction again to raise the "low" value used to the threshold value / 10. (PR #159, @dgergel)
 
 ## [0.14.0] - 2021-12-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Update wet day frequency correction to incorporate method additions from Hempel et al 2013. (PR #162, @dgergel)
-- Update wet day frequency correction again to raise the "low" value used to the threshold value / 10. (PR #159, @dgergel)
+- Update wet day frequency correction to incorporate method additions from Hempel et al 2013. (PRs #162 and #159, @dgergel)
 
 ## [0.14.0] - 2021-12-21
 ### Changed

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -529,19 +529,23 @@ def apply_wet_day_frequency_correction(ds, process):
 
     Notes
     -------
-    [1] A.J. Cannon, S.R. Sobie, & T.Q. Murdock, "Bias correction of GCM
+    [1] A.J. Cannon, S.R. Sobie, and T.Q. Murdock (2015), "Bias correction of GCM
         precipitation by quantile mapping: How well do methods preserve
         changes in quantiles and extremes?", Journal of Climate, vol.
         28, Issue 7, pp. 6938-6959.
+    [2] S. Hempel, K. Frieler, L. Warszawski, J. Schewe, and F. Piotek (2013), "A trend-preserving bias correction - The ISI-MIP approach", Earth Syst. Dynam. vol. 4, pp. 219-236.
     """
-    threshold = 0.05  # mm/day
+    # threshold from Hempel et al 2013
+    threshold = 1.0  # mm/day
     # adjusted "low" value from the original epsilon in Cannon et al 2015 to
-    # avoid having some values get extremely large
-    low = threshold / 10.0
+    # avoid having some values get extremely large 
+    low = threshold / 2.0
 
     if process == "pre":
         # includes very small values that are negative in CMIP6 output
-        ds_corrected = ds.where(ds > 0.0, np.random.uniform(low=low, high=threshold))
+        ds_corrected = ds.where(
+            ds > threshold, np.random.uniform(low=low, high=threshold)
+        )
     elif process == "post":
         ds_corrected = ds.where(ds >= threshold, 0.0)
     else:

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -538,7 +538,7 @@ def apply_wet_day_frequency_correction(ds, process):
     # threshold from Hempel et al 2013
     threshold = 1.0  # mm/day
     # adjusted "low" value from the original epsilon in Cannon et al 2015 to
-    # avoid having some values get extremely large 
+    # avoid having some values get extremely large
     low = threshold / 2.0
 
     if process == "pre":


### PR DESCRIPTION
This PR updates the WDF correction with additions from the ISI-MIP WDF correction method outlined in Hempel et al 2013 (https://esd.copernicus.org/articles/4/219/2013/esd-4-219-2013.html). 

Three key changes are made: 
- raises threshold to 1mm (from Hempel et al 2013)
- applies correction to values _below_ the threshold, not just to zeroes 
- raises "low" value in uniform distribution to threshold / 2

These changes are made to address the ongoing challenges of applying a WDF correction at a global scale and having mismatched dry days in the reference and model output, resulting in some precip values being physically unrealistic. 