### PR TITLE
floor and ceiling for DTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Update wet day frequency correction to incorporate method additions from Hempel et al 2013. (PRs #162 and #159, @dgergel)
+- floor and ceiling for DTR (PR #163 @emileten)
 
 ## [0.14.0] - 2021-12-21
 ### Changed

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -566,17 +566,31 @@ def correct_wetday_frequency(x, out, process):
 
 
 @dodola_cli.command(
-    help="Correct small values of diurnal temperature range (DTR) in a dataset"
+    help="Apply a floor to diurnal temperature range (DTR) in a dataset"
 )
 @click.argument("x", required=True)
 @click.option("--out", "-o", required=True)
 @click.option(
-    "--threshold", "-t", help="Threshold for correcting small DTR values up to"
+    "--floor", "-f", help="floor to apply to DTR values"
 )
-def correct_dtr(x, out, floor=1.0, ceiling=70.0):
-    """Correct small values of diurnal temperature range (DTR) in a dataset"""
+def apply_dtr_floor(x, out, floor=1.0):
+    """Apply a floor to diurnal temperature range (DTR) in a dataset"""
+    services.apply_dtr_floor(
+        str(x), out=str(out), floor=float(floor)
+    )
+
+@dodola_cli.command(
+    help="Apply a ceiling to diurnal temperature range (DTR) in a dataset"
+)
+@click.argument("x", required=True)
+@click.option("--out", "-o", required=True)
+@click.option(
+    "--ceiling", "-c", help="ceiling to apply to DTR values"
+)
+def apply_non_polar_dtr_ceiling(x, out, ceiling=70.0):
+    """Apply a ceiling to diurnal temperature range (DTR) in a dataset"""
     services.correct_dtr(
-        str(x), out=str(out), floor=float(floor), ceiling=float(ceiling)
+        str(x), out=str(out), ceiling=float(ceiling)
     )
 
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -573,9 +573,11 @@ def correct_wetday_frequency(x, out, process):
 @click.option(
     "--threshold", "-t", help="Threshold for correcting small DTR values up to"
 )
-def correct_dtr(x, out, threshold=1.0):
+def correct_dtr(x, out, floor=1., ceiling=70.):
     """Correct small values of diurnal temperature range (DTR) in a dataset"""
-    services.correct_small_dtr(str(x), out=str(out), threshold=float(threshold))
+    services.correct_dtr(
+        str(x), out=str(out), floor=float(floor), ceiling=float(ceiling)
+    )
 
 
 @dodola_cli.command(help="Validate a CMIP6, bias corrected or downscaled dataset")

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -584,7 +584,7 @@ def apply_dtr_floor(x, out, floor=1.0):
 @click.option("--ceiling", "-c", help="ceiling to apply to DTR values")
 def apply_non_polar_dtr_ceiling(x, out, ceiling=70.0):
     """Apply a ceiling to diurnal temperature range (DTR) in a dataset"""
-    services.correct_dtr(str(x), out=str(out), ceiling=float(ceiling))
+    services.apply_non_polar_dtr_ceiling(str(x), out=str(out), ceiling=float(ceiling))
 
 
 @dodola_cli.command(help="Validate a CMIP6, bias corrected or downscaled dataset")

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -573,7 +573,7 @@ def correct_wetday_frequency(x, out, process):
 @click.option(
     "--threshold", "-t", help="Threshold for correcting small DTR values up to"
 )
-def correct_dtr(x, out, floor=1., ceiling=70.):
+def correct_dtr(x, out, floor=1.0, ceiling=70.0):
     """Correct small values of diurnal temperature range (DTR) in a dataset"""
     services.correct_dtr(
         str(x), out=str(out), floor=float(floor), ceiling=float(ceiling)

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -570,28 +570,21 @@ def correct_wetday_frequency(x, out, process):
 )
 @click.argument("x", required=True)
 @click.option("--out", "-o", required=True)
-@click.option(
-    "--floor", "-f", help="floor to apply to DTR values"
-)
+@click.option("--floor", "-f", help="floor to apply to DTR values")
 def apply_dtr_floor(x, out, floor=1.0):
     """Apply a floor to diurnal temperature range (DTR) in a dataset"""
-    services.apply_dtr_floor(
-        str(x), out=str(out), floor=float(floor)
-    )
+    services.apply_dtr_floor(str(x), out=str(out), floor=float(floor))
+
 
 @dodola_cli.command(
     help="Apply a ceiling to diurnal temperature range (DTR) in a dataset"
 )
 @click.argument("x", required=True)
 @click.option("--out", "-o", required=True)
-@click.option(
-    "--ceiling", "-c", help="ceiling to apply to DTR values"
-)
+@click.option("--ceiling", "-c", help="ceiling to apply to DTR values")
 def apply_non_polar_dtr_ceiling(x, out, ceiling=70.0):
     """Apply a ceiling to diurnal temperature range (DTR) in a dataset"""
-    services.correct_dtr(
-        str(x), out=str(out), ceiling=float(ceiling)
-    )
+    services.correct_dtr(str(x), out=str(out), ceiling=float(ceiling))
 
 
 @dodola_cli.command(help="Validate a CMIP6, bias corrected or downscaled dataset")

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -555,8 +555,8 @@ def apply_wet_day_frequency_correction(ds, process):
 
 def dtr_floor(ds, floor):
     """
-    Converts all diurnal temperature range (DTR) values below a threshold
-    to the threshold value.
+    Converts all diurnal temperature range (DTR) values strictly below a floor
+    to that floor.
 
     Parameters
     ----------
@@ -575,8 +575,8 @@ def dtr_floor(ds, floor):
 
 def non_polar_dtr_ceiling(ds, ceiling):
     """
-    Converts all diurnal temperature range (DTR) values above a threshold
-    to the threshold value, for regions between the 60th south and north parallel.
+    Converts all non-polar (regions between the 60th south and north parallel) diurnal temperature range (DTR) values strictly above a ceiling
+    to that ceiling.
 
     Parameters
     ----------

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -553,7 +553,7 @@ def apply_wet_day_frequency_correction(ds, process):
     return ds_corrected
 
 
-def apply_dtr_floor(ds, floor):
+def dtr_floor(ds, floor):
     """
     Converts all diurnal temperature range (DTR) values below a threshold
     to the threshold value.
@@ -573,7 +573,7 @@ def apply_dtr_floor(ds, floor):
     return ds_corrected
 
 
-def apply_non_polar_dtr_ceiling(ds, ceiling):
+def non_polar_dtr_ceiling(ds, ceiling):
     """
     Converts all diurnal temperature range (DTR) values above a threshold
     to the threshold value, for regions between the 60th south and north parallel.

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -553,7 +553,7 @@ def apply_wet_day_frequency_correction(ds, process):
     return ds_corrected
 
 
-def apply_small_dtr_correction(ds, threshold):
+def apply_dtr_floor(ds, floor):
     """
     Converts all diurnal temperature range (DTR) values below a threshold
     to the threshold value.
@@ -561,7 +561,7 @@ def apply_small_dtr_correction(ds, threshold):
     Parameters
     ----------
     ds : xr.Dataset
-    threshold : int or float
+    floor : int or float
 
     Returns
     -------
@@ -569,7 +569,27 @@ def apply_small_dtr_correction(ds, threshold):
 
     """
 
-    ds_corrected = ds.where(ds >= threshold, threshold)
+    ds_corrected = ds.where(ds >= floor, floor)
+    return ds_corrected
+
+
+def apply_non_polar_dtr_ceiling(ds, ceiling):
+    """
+    Converts all diurnal temperature range (DTR) values above a threshold
+    to the threshold value, for regions between the 60th south and north parallel.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+    ceiling : int or float
+
+    Returns
+    -------
+    xr.Dataset
+
+    """
+
+    ds_corrected = ds.where((ds <= ceiling) & (ds.lat > -60) & (ds.lat < 60), ceiling)
     return ds_corrected
 
 
@@ -760,7 +780,7 @@ def _test_dtr_range(ds, var, data_type):
     # test all but polar regions
     non_polar_max = ds[var].where((ds.lat > -60) & (ds.lat < 60)).max()
     assert (
-        non_polar_max < 70
+        non_polar_max <= 70
     ), "diurnal temperature range max is {} for non-polar regions".format(non_polar_max)
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -13,7 +13,8 @@ from dodola.core import (
     train_analogdownscaling,
     adjust_analogdownscaling,
     validate_dataset,
-    apply_small_dtr_correction,
+    apply_dtr_floor,
+    apply_non_polar_dtr_ceiling,
     xclim_units_any2pint,
     xclim_units_pint2cf,
 )
@@ -641,8 +642,8 @@ def correct_wet_day_frequency(x, out, process):
 
 
 @log_service
-def correct_small_dtr(x, out, threshold=1.0):
-    """Corrects small diurnal temperature range (DTR) values in a dataset
+def correct_dtr(x, out, floor=1.0, ceiling=70.0):
+    """Corrects diurnal temperature range (DTR) values in a dataset
 
     Parameters
     ----------
@@ -650,12 +651,15 @@ def correct_small_dtr(x, out, threshold=1.0):
         Storage URL to input xr.Dataset that will be corrected.
     out : str
         Storage URL to write corrected output to.
-    threshold : int or float, optional
-        All DTR values lower than this value are corrected to the threshold value.
+    floor : int or float, optional
+        All DTR values lower than this value are corrected to that value.
+    ceiling : int or float, optional
+        All DTR values above this value are corrected to that value.
     """
     ds = storage.read(x)
-    ds_corrected = apply_small_dtr_correction(ds, threshold)
-    storage.write(out, ds_corrected)
+    ds = apply_dtr_floor(ds, floor)
+    ds = apply_non_polar_dtr_ceiling(ds, ceiling)
+    storage.write(out, ds)
 
 
 @log_service

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -642,8 +642,11 @@ def correct_wet_day_frequency(x, out, process):
 
 
 @log_service
-def apply_dtr_floor(x, out, floor=1.):
-    """Corrects diurnal temperature range (DTR) values in a dataset
+def apply_dtr_floor(x, out, floor=1.0):
+    """Applies a floor to diurnal temperature range (DTR) values
+
+    This constrains the values in a DTR dataset by applying a floor. The floor is assigned to the value of the
+    data points which have their value strictly below the floor.
 
     Parameters
     ----------
@@ -658,9 +661,13 @@ def apply_dtr_floor(x, out, floor=1.):
     ds = dtr_floor(ds, floor)
     storage.write(out, ds)
 
+
 @log_service
-def apply_non_polar_dtr_ceiling(x, out, ceiling=70.):
-    """Corrects diurnal temperature range (DTR) values in a dataset
+def apply_non_polar_dtr_ceiling(x, out, ceiling=70.0):
+    """Applies a ceiling to diurnal temperature range (DTR) values
+
+    This constrains the values in a DTR dataset by applying a ceiling. The ceiling is assigned to the value of the
+    data points which have their value strictly above the ceiling.
 
     Parameters
     ----------

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -13,8 +13,8 @@ from dodola.core import (
     train_analogdownscaling,
     adjust_analogdownscaling,
     validate_dataset,
-    apply_dtr_floor,
-    apply_non_polar_dtr_ceiling,
+    dtr_floor,
+    non_polar_dtr_ceiling,
     xclim_units_any2pint,
     xclim_units_pint2cf,
 )
@@ -642,7 +642,7 @@ def correct_wet_day_frequency(x, out, process):
 
 
 @log_service
-def correct_dtr(x, out, floor=1.0, ceiling=70.0):
+def apply_dtr_floor(x, out, floor=1.):
     """Corrects diurnal temperature range (DTR) values in a dataset
 
     Parameters
@@ -653,12 +653,26 @@ def correct_dtr(x, out, floor=1.0, ceiling=70.0):
         Storage URL to write corrected output to.
     floor : int or float, optional
         All DTR values lower than this value are corrected to that value.
+    """
+    ds = storage.read(x)
+    ds = dtr_floor(ds, floor)
+    storage.write(out, ds)
+
+@log_service
+def apply_non_polar_dtr_ceiling(x, out, ceiling=70.):
+    """Corrects diurnal temperature range (DTR) values in a dataset
+
+    Parameters
+    ----------
+    x : str
+        Storage URL to input xr.Dataset that will be corrected.
+    out : str
+        Storage URL to write corrected output to.
     ceiling : int or float, optional
         All DTR values above this value are corrected to that value.
     """
     ds = storage.read(x)
-    ds = apply_dtr_floor(ds, floor)
-    ds = apply_non_polar_dtr_ceiling(ds, ceiling)
+    ds = non_polar_dtr_ceiling(ds, ceiling)
     storage.write(out, ds)
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -26,7 +26,9 @@ from dodola.services import (
 import dodola.repository as repository
 
 
-def _datafactory(x, start_time="1950-01-01", variable_name="fakevariable", lon=1., lat=1.):
+def _datafactory(
+    x, start_time="1950-01-01", variable_name="fakevariable", lon=1.0, lat=1.0
+):
     """Populate xr.Dataset with synthetic data for testing"""
     start_time = str(start_time)
     if x.ndim != 1:
@@ -794,14 +796,14 @@ def test_correct_dtr():
         )
     )
 
+
 def test_correct_dtr_not_applying_ceiling():
     """Test that diurnal temperature range (DTR) correction applies floor and/or ceiling specified"""
     # Make some fake dtr data
     n = 700
-    floor = 1.0
     ceiling = 70.0
     ts = np.linspace(0.0, 100, num=n)
-    ds_dtr = _datafactory(ts, start_time="1950-01-01", lat=-61.)
+    ds_dtr = _datafactory(ts, start_time="1950-01-01", lat=-61.0)
     in_url = "memory://test_correct_small_dtr/an/input/path.zarr"
     out_url = "memory://test_correct_small_dtr/an/output/path.zarr"
     repository.write(in_url, ds_dtr)
@@ -810,7 +812,6 @@ def test_correct_dtr_not_applying_ceiling():
     ds_dtr_corrected = repository.read(out_url)
 
     assert ds_dtr_corrected == ds_dtr
-
 
 
 @pytest.mark.parametrize("kind", ["multiplicative", "additive"])

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -793,7 +793,6 @@ def test_apply_dtr_floor():
 def test_apply_non_polar_dtr_ceiling():
     """Test diurnal temperature range (DTR) non polar dtr ceiling"""
 
-
     # case 1 : non polar regions, should be applied
     # Make some fake dtr data
     n = 700

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -770,9 +770,9 @@ def test_correct_wet_day_frequency(process):
 def test_apply_dtr_floor():
     """Test diurnal temperature range (DTR) floor constraint"""
     # Make some fake dtr data
-    n = 700
-    floor = 1.0
-    ts = np.linspace(0.0, 100, num=n)
+    n = 10
+    floor = 5.0
+    ts = np.linspace(0.0, 10, num=n)
     ds_dtr = _datafactory(ts, start_time="1950-01-01")
     in_url = "memory://test_correct_small_dtr/an/input/path.zarr"
     out_url = "memory://test_correct_small_dtr/an/output/path.zarr"
@@ -795,9 +795,9 @@ def test_apply_non_polar_dtr_ceiling():
 
     # case 1 : non polar regions, should be applied
     # Make some fake dtr data
-    n = 700
-    ceiling = 70.0
-    ts = np.linspace(0.0, 100, num=n)
+    n = 10
+    ceiling = 5.0
+    ts = np.linspace(0.0, 10, num=n)
     ds_dtr = _datafactory(ts, start_time="1950-01-01")
     in_url = "memory://test_correct_small_dtr/an/input/path.zarr"
     out_url = "memory://test_correct_small_dtr/an/output/path.zarr"
@@ -815,9 +815,9 @@ def test_apply_non_polar_dtr_ceiling():
 
     # case 2 : polar regions, shouldn't be applied
     # Make some fake dtr data
-    n = 700
+    n = 10
     ceiling = 70.0
-    ts = np.linspace(0.0, 100, num=n)
+    ts = np.linspace(65.0, 75.0, num=n)
     ds_dtr = _datafactory(ts, start_time="1950-01-01", lat=-61.0)
     in_url = "memory://test_correct_small_dtr/an/input/path.zarr"
     out_url = "memory://test_correct_small_dtr/an/output/path.zarr"


### PR DESCRIPTION
- [x] helps closing (but does not close) : 

- #468, #470, #472, #473, #474, #475, #476, #477, #481 from https://github.com/ClimateImpactLab/downscaleCMIP6/issues

- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

- rename the DTR correction core function to 'floor...'
- added an equivalent one for a ceiling only applied to [-60, 60]. Default ceiling is 70. 
-  merged these two functionalities in one service renamed to correct_dtr
- added tests for the latter 
-  accordingly modified click 
- changed `<` to `<=` in the DTR range validation 

This means our DTR 'validation' looses its meaning from when the DTR correction is applied on. It's a quick-and-dirty fix. 

@dgergel this is just applying a cap at 70. This follows what I saw in the data (data points away from 60th north parallel but with a value significantly larger than 70) and me realizing (1) that 60th north parallel already crosses a significant european population area and (2) 70 diff in kelvin is already quite extreme 