### PR TITLE
Add max precip ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add maximum precipitation adjustment service that applies a ceiling to precipitation values above a user-defined threshold. (PR #164, @dgergel)
 - Update wet day frequency correction to incorporate method additions from Hempel et al 2013. (PRs #162 and #159, @dgergel)
 
 ## [0.14.0] - 2021-12-21

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -565,6 +565,19 @@ def correct_wetday_frequency(x, out, process):
     services.correct_wet_day_frequency(str(x), out=str(out), process=str(process))
 
 
+@dodola_cli.command(help="Adjust maximum precipitation in a dataset")
+@click.argument("x", required=True)
+@click.option("--out", "-o", required=True)
+@click.option(
+    "--threshold", "-t", help="Threshold for correcting maximum precipitation"
+)
+def adjust_maximum_precipitation(x, out, threshold=3000.0):
+    """Apply maximum precipitation threshold to a dataset"""
+    services.adjust_maximum_precipitation(
+        str(x), out=str(out), threshold=float(threshold)
+    )
+
+
 @dodola_cli.command(
     help="Correct small values of diurnal temperature range (DTR) in a dataset"
 )

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -777,11 +777,11 @@ def _test_maximum_precip(ds, var):
     """
     Tests that max precip is reasonable
     """
-    threshold = 2000  # in mm, max observed is 1.825m --> maximum occurs between 0.5-0.8
-    max_precip = ds[var].max().values
-    num_precip_values_over_threshold = ds[var].where(ds[var] > threshold).count().values
+    threshold = 3000  # in mm, max observed is 1.825m --> maximum occurs between 0.5-0.8
+    max_precip = ds[var].max().load().values
+    num_precip_values_over_threshold = ds[var].where(ds[var] > threshold).count().load().values
     assert (
         num_precip_values_over_threshold == 0
-    ), "maximum precip is {} mm and there are {} values over 2000mm".format(
+    ), "maximum precip is {} mm and there are {} values over 3000mm".format(
         max_precip, num_precip_values_over_threshold
     )

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -573,6 +573,24 @@ def apply_small_dtr_correction(ds, threshold):
     return ds_corrected
 
 
+def apply_precip_ceiling(ds, ceiling):
+    """
+    Converts all precip values above a threshold to the threshold value, uniformly across space and time.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+    ceiling : int or float
+
+    Returns
+    -------
+    xr.Dataset
+
+    """
+    ds_corrected = ds.where(ds <= ceiling, ceiling)
+    return ds_corrected
+
+
 def validate_dataset(ds, var, data_type, time_period="future"):
     """
     Validate a Dataset. Valid for CMIP6, bias corrected and downscaled.
@@ -779,7 +797,9 @@ def _test_maximum_precip(ds, var):
     """
     threshold = 3000  # in mm, max observed is 1.825m --> maximum occurs between 0.5-0.8
     max_precip = ds[var].max().load().values
-    num_precip_values_over_threshold = ds[var].where(ds[var] > threshold).count().load().values
+    num_precip_values_over_threshold = (
+        ds[var].where(ds[var] > threshold).count().load().values
+    )
     assert (
         num_precip_values_over_threshold == 0
     ), "maximum precip is {} mm and there are {} values over 3000mm".format(

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -14,6 +14,7 @@ from dodola.core import (
     adjust_analogdownscaling,
     validate_dataset,
     apply_small_dtr_correction,
+    apply_precip_ceiling,
     xclim_units_any2pint,
     xclim_units_pint2cf,
 )
@@ -655,6 +656,25 @@ def correct_small_dtr(x, out, threshold=1.0):
     """
     ds = storage.read(x)
     ds_corrected = apply_small_dtr_correction(ds, threshold)
+    storage.write(out, ds_corrected)
+
+
+@log_service
+def adjust_maximum_precipitation(x, out, threshold=3000.0):
+    """Adjusts maximum precipitation in a dataset
+
+    Parameters
+    ----------
+    x : str
+        Storage URL to input xr.Dataset that will be corrected.
+    out : str
+        Storage URL to write corrected output to.
+    threshold : int or float, optional
+        All precipitation values lower than this value are corrected to the threshold value.
+    """
+
+    ds = storage.read(x)
+    ds_corrected = apply_precip_ceiling(ds, threshold)
     storage.write(out, ds_corrected)
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -15,6 +15,7 @@ from dodola.services import (
     remove_leapdays,
     clean_cmip6,
     correct_wet_day_frequency,
+    adjust_maximum_precipitation,
     train_qdm,
     apply_qdm,
     train_qplad,
@@ -784,6 +785,29 @@ def test_correct_small_dtr():
         .where(ds_dtr["fakevariable"] < threshold, drop=True)
         .all()
         >= threshold
+    )
+
+
+def test_adjust_maximum_precipitation():
+    """Test that maximum precipitation adjustment corrects precipitation values above a set threshold"""
+    # make some fake precip data
+    n = 700
+    ts = np.linspace(0.0, 4000, num=n)
+    threshold = 3000  # mm/day
+    ds_precip = _datafactory(ts, start_time="1950-01-01")
+    in_url = "memory://test_adjust_maximum_precipitation/an/input/path.zarr"
+    out_url = "memory://test_adjust_maximum_precipitation/an/output/path.zarr"
+    repository.write(in_url, ds_dtr)
+
+    adjust_maximum_precipitation(in_url, out=out_url, threshold=threshold)
+    ds_precip_corrected = repository.read(out_url)
+
+    # all values above threshold should have been set to the threshold value
+    assert (
+        ds_precip_corrected["fakevariable"]
+        .where(ds_precip["fakevariable"] > threshold, drop=True)
+        .all()
+        <= threshold
     )
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -797,7 +797,7 @@ def test_adjust_maximum_precipitation():
     ds_precip = _datafactory(ts, start_time="1950-01-01")
     in_url = "memory://test_adjust_maximum_precipitation/an/input/path.zarr"
     out_url = "memory://test_adjust_maximum_precipitation/an/output/path.zarr"
-    repository.write(in_url, ds_dtr)
+    repository.write(in_url, ds_precip)
 
     adjust_maximum_precipitation(in_url, out=out_url, threshold=threshold)
     ds_precip_corrected = repository.read(out_url)


### PR DESCRIPTION
This PR adds a maximum precipitation adjustment service so that maximum precipitation values above a threshold get adjusted to that threshold. 

CLI interface is: 

```
dodola adjust_maximum_precipitation /path/to/precip_to_correct.zarr \
--out /path/to/corrected_precip.zarr
-t 3000.0
```

This will then be added to the e2e precip downscaling workflow (no related issues to list at this time). 

Note: this also updates the maximum validation precip threshold to 3000 mm (from its previous max of 2000mm). 