### PR TITLE
Corrected DTR ceiling

### DIFF
--- a/dodola/core.py
+++ b/dodola/core.py
@@ -589,7 +589,11 @@ def non_polar_dtr_ceiling(ds, ceiling):
 
     """
 
-    ds_corrected = ds.where(((ds <= ceiling) & (ds['lat'] > -60) & (ds['lat'] < 60) ) | (ds['lat'] <= -60 or ds['lat'] >= 60), ceiling)
+    ds_corrected = ds.where(
+        ((ds <= ceiling) & (ds["lat"] > -60) & (ds["lat"] < 60))
+        | (ds["lat"] <= -60 or ds["lat"] >= 60),
+        ceiling,
+    )
     return ds_corrected
 
 

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -589,7 +589,7 @@ def non_polar_dtr_ceiling(ds, ceiling):
 
     """
 
-    ds_corrected = ds.where((ds <= ceiling) & (ds.lat > -60) & (ds.lat < 60), ceiling)
+    ds_corrected = ds.where(((ds <= ceiling) & (ds['lat'] > -60) & (ds['lat'] < 60) ) | (ds['lat'] <= -60 or ds['lat'] >= 60), ceiling)
     return ds_corrected
 
 

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -807,12 +807,19 @@ def test_apply_non_polar_dtr_ceiling():
     apply_non_polar_dtr_ceiling(in_url, out=out_url, ceiling=ceiling)
     ds_dtr_corrected = repository.read(out_url)
 
+    # check values that should be capped
     assert all(
         x == ceiling
         for x in ds_dtr_corrected["fakevariable"].where(
             ds_dtr["fakevariable"] > ceiling, drop=True
         )
     )
+
+    # check values that should not be capped
+    left = ds_dtr_corrected["fakevariable"].where(ds_dtr["fakevariable"] <= ceiling, drop=True)
+    right = ds_dtr["fakevariable"].where(ds_dtr["fakevariable"] <= ceiling, drop=True)
+    xr.testing.assert_equal(left, right)
+
 
     # case 2 : polar regions, shouldn't be applied
     # Make some fake dtr data
@@ -827,7 +834,7 @@ def test_apply_non_polar_dtr_ceiling():
     apply_non_polar_dtr_ceiling(in_url, out=out_url, ceiling=ceiling)
     ds_dtr_corrected = repository.read(out_url)
 
-    assert ds_dtr_corrected == ds_dtr
+    np.testing.assert_equal(ds_dtr['fakevariable'].values, ds_dtr_corrected['fakevariable'].values)
 
 
 def test_adjust_maximum_precipitation():

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -816,10 +816,11 @@ def test_apply_non_polar_dtr_ceiling():
     )
 
     # check values that should not be capped
-    left = ds_dtr_corrected["fakevariable"].where(ds_dtr["fakevariable"] <= ceiling, drop=True)
+    left = ds_dtr_corrected["fakevariable"].where(
+        ds_dtr["fakevariable"] <= ceiling, drop=True
+    )
     right = ds_dtr["fakevariable"].where(ds_dtr["fakevariable"] <= ceiling, drop=True)
     xr.testing.assert_equal(left, right)
-
 
     # case 2 : polar regions, shouldn't be applied
     # Make some fake dtr data
@@ -834,7 +835,9 @@ def test_apply_non_polar_dtr_ceiling():
     apply_non_polar_dtr_ceiling(in_url, out=out_url, ceiling=ceiling)
     ds_dtr_corrected = repository.read(out_url)
 
-    np.testing.assert_equal(ds_dtr['fakevariable'].values, ds_dtr_corrected['fakevariable'].values)
+    np.testing.assert_equal(
+        ds_dtr["fakevariable"].values, ds_dtr_corrected["fakevariable"].values
+    )
 
 
 def test_adjust_maximum_precipitation():


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] docs reflect changes
- [ ] entry in CHANGELOG.md

This corrects a mistake introduced by https://github.com/ClimateImpactLab/dodola/pull/163. The functionality to cap non-polar DTR values had an error in its implementation that lead all polar values to be modified. The tests couldn't catch this because they were also wrong, using `==` to compare `xarray.Dataset` objects. 

This PR : 

- Corrects the boolean condition expression in the cap function to preserve polar values 
- Corrects the cap function test by making use of `xarray.testing.assert_equals` and adds an additional test case to verify that values that should _not_ be capped (because those are _not_ out of range) are indeed not capped. 