### PR TITLE
corrected DTR ceiling boolean expression and tests accordingly

### DIFF
--- a/dodola/core.py
+++ b/dodola/core.py
@@ -590,7 +590,10 @@ def non_polar_dtr_ceiling(ds, ceiling):
     """
 
     ds_corrected = ds.where(
-        (ds <= ceiling) | (ds["lat"] <= -60 or ds["lat"] >= 60), ceiling
+        xr.ufuncs.logical_or(
+            ds <= ceiling, xr.ufuncs.logical_or(ds["lat"] <= -60, ds["lat"] >= 60)
+        ),
+        ceiling,
     )
 
     return ds_corrected


### PR DESCRIPTION
This corrects a bug introduced by https://github.com/ClimateImpactLab/dodola/pull/165. 

In the DTR ceiling we were making use of direct comparison operators like `or` etc... Which lead to a typical error with arrays. 

This was not caught by the tests because there was only _one_ latitude coordinate. 

Changes : 

- switched to `xr.ufuncs` logical operators
- enhanced tests by using arrays with with several latitude coordinates. 

I am not doing anything to the changelog because this is just an extension of #165.
