### PR TITLE
Remove excess unit conversion info logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Remove duplicated service-level logging info lines of code introduced by PR #148 (PR #168, @emileten)
 
 ## [0.15.1] - 2021-12-29
 ### Fixed

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -415,6 +415,8 @@ def xclim_units_any2pint(ds, var):
     -------
     xr.Dataset with `var` units str attribute converted to xclim's pint registry format
     """
+
+    logger.info(f"Reformatting {variable} unit string representation")
     ds[var].attrs["units"] = str(xclim_units.units2pint(ds[var].attrs["units"]))
     return ds
 
@@ -430,6 +432,7 @@ def xclim_units_pint2cf(ds, var):
     -------
     xr.Dataset with `var` units str attribute converted to CF format
     """
+    logger.info(f"Reformatting {variable} unit string representation")
     ds[var].attrs["units"] = xclim_units.pint2cfunits(
         xclim_units.units2pint(ds[var].attrs["units"])
     )

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -416,7 +416,7 @@ def xclim_units_any2pint(ds, var):
     xr.Dataset with `var` units str attribute converted to xclim's pint registry format
     """
 
-    logger.info(f"Reformatting {variable} unit string representation")
+    logger.info(f"Reformatting {var} unit string representation")
     ds[var].attrs["units"] = str(xclim_units.units2pint(ds[var].attrs["units"]))
     return ds
 
@@ -432,7 +432,7 @@ def xclim_units_pint2cf(ds, var):
     -------
     xr.Dataset with `var` units str attribute converted to CF format
     """
-    logger.info(f"Reformatting {variable} unit string representation")
+    logger.info(f"Reformatting {var} unit string representation")
     ds[var].attrs["units"] = xclim_units.pint2cfunits(
         xclim_units.units2pint(ds[var].attrs["units"])
     )

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -240,7 +240,6 @@ def train_qdm(
         hist = hist.isel(isel_slice)
         ref = ref.isel(isel_slice)
 
-
     ref = xclim_units_any2pint(ref, variable)
     hist = xclim_units_any2pint(hist, variable)
 
@@ -320,7 +319,6 @@ def apply_qdm(
     qdm_ds.load()
     sim_ds.load()
 
-    
     sim_ds = xclim_units_any2pint(sim_ds, variable)
 
     adjusted_ds = adjust_quantiledeltamapping(
@@ -396,7 +394,6 @@ def train_qplad(
     ref_coarse.load()
     ref_fine.load()
 
-    
     ref_coarse = xclim_units_any2pint(ref_coarse, variable)
     ref_fine = xclim_units_any2pint(ref_fine, variable)
 
@@ -483,7 +480,6 @@ def apply_qplad(
 
     variable = str(variable)
 
-    
     sim_ds = xclim_units_any2pint(sim_ds, variable)
     for var in qplad_ds:
         qplad_ds = xclim_units_any2pint(qplad_ds, var)

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -240,7 +240,7 @@ def train_qdm(
         hist = hist.isel(isel_slice)
         ref = ref.isel(isel_slice)
 
-    logger.info(f"Converting {variable} units to xclim pint compatible units")
+
     ref = xclim_units_any2pint(ref, variable)
     hist = xclim_units_any2pint(hist, variable)
 
@@ -320,7 +320,7 @@ def apply_qdm(
     qdm_ds.load()
     sim_ds.load()
 
-    logger.info(f"Converting {variable} units to xclim pint compatible units")
+    
     sim_ds = xclim_units_any2pint(sim_ds, variable)
 
     adjusted_ds = adjust_quantiledeltamapping(
@@ -332,7 +332,6 @@ def apply_qdm(
         include_quantiles=True,
     )
 
-    logger.info(f"Converting {variable} units back to CF compatible units")
     adjusted_ds = xclim_units_pint2cf(adjusted_ds, variable)
 
     if new_attrs:
@@ -397,7 +396,7 @@ def train_qplad(
     ref_coarse.load()
     ref_fine.load()
 
-    logger.info(f"Converting {variable} units to xclim pint compatible units")
+    
     ref_coarse = xclim_units_any2pint(ref_coarse, variable)
     ref_fine = xclim_units_any2pint(ref_fine, variable)
 
@@ -484,7 +483,7 @@ def apply_qplad(
 
     variable = str(variable)
 
-    logger.info(f"Converting {variable} units to xclim pint compatible units")
+    
     sim_ds = xclim_units_any2pint(sim_ds, variable)
     for var in qplad_ds:
         qplad_ds = xclim_units_any2pint(qplad_ds, var)


### PR DESCRIPTION
- [x] closes #148 
- [x] tests added / passed
- [ ] docs reflect changes
- [x] entry in CHANGELOG.md

- removed the excess logging messages from #143. Those are in 'excess' because are duplicates : they inform about something happening in a subsequent call to a function, every time this call happens. 
- therefore, I replaced those by a single `logger.info` message happening within this given function. Did that for both cf -> pint function and vice versa. 