### PR TITLE
extend minimum temperature tolerance from 150 K to 130 K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve README.md. (PR #169, @brews)
 ### Changed
 - Remove duplicated service-level logging info lines of code introduced by PR #148 (PR #168, @emileten)
+- Decrease validation temperature range min to 130 (PR #170, @emileten)
 
 ## [0.15.1] - 2021-12-29
 ### Fixed

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -754,7 +754,7 @@ def _test_temp_range(ds, var):
     """
     Ensure temperature values are in a valid range
     """
-    assert (ds[var].min() > 150) and (
+    assert (ds[var].min() > 130) and (
         ds[var].max() < 360
     ), "{} values are invalid".format(var)
 


### PR DESCRIPTION
- [x] closes https://github.com/ClimateImpactLab/downscaleCMIP6/issues/510
- [x] tests added / passed
- [ ] docs reflect changes
- [x] entry in CHANGELOG.md

This decreases the lower bound of the temperature validation window from 150 to 130 Kelvin to let in the pipeline an isolated extreme value from the raw ACCESS-ESM1 historical data. As noted here, this extreme value does not seem to be indicative of a general problem with that GCM. 