### PR TITLE
Fix wetday frequency correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Fix the wetday frequency correction so that different replacement values are used, rather than a single one (PR #174, @emileten)
 
 ## [0.16.0] - 2022-01-19
 ### Added

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -518,7 +518,7 @@ def xclim_convert_360day_calendar_interpolate(
         return ds_out
 
 
-def apply_wet_day_frequency_correction(ds, process, var='pr'):
+def apply_wet_day_frequency_correction(ds, process, var="pr"):
     """
 
     Parameters
@@ -548,7 +548,8 @@ def apply_wet_day_frequency_correction(ds, process, var='pr'):
     if process == "pre":
         # includes very small values that are negative in CMIP6 output
         ds[var] = ds[var].where(
-            ds[var] >= threshold, np.random.uniform(low=low, high=threshold, size=ds[var].shape)
+            ds[var] >= threshold,
+            np.random.uniform(low=low, high=threshold, size=ds[var].shape),
         )
     elif process == "post":
         ds[var] = ds[var].where(ds[var] >= threshold, 0.0)

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -518,14 +518,14 @@ def xclim_convert_360day_calendar_interpolate(
         return ds_out
 
 
-def apply_wet_day_frequency_correction(ds, process, var="pr"):
+def apply_wet_day_frequency_correction(ds, process, variable="pr"):
     """
 
     Parameters
     ----------
     ds : xr.Dataset
     process : {"pre", "post"}
-    var: str
+    variable: str
 
     Returns
     -------
@@ -547,12 +547,12 @@ def apply_wet_day_frequency_correction(ds, process, var="pr"):
 
     if process == "pre":
         # includes very small values that are negative in CMIP6 output
-        ds[var] = ds[var].where(
-            ds[var] >= threshold,
-            np.random.uniform(low=low, high=threshold, size=ds[var].shape),
+        ds[variable] = ds[variable].where(
+            ds[variable] >= threshold,
+            np.random.uniform(low=low, high=threshold, size=ds[variable].shape),
         )
     elif process == "post":
-        ds[var] = ds[var].where(ds[var] >= threshold, 0.0)
+        ds[variable] = ds[variable].where(ds[variable] >= threshold, 0.0)
     else:
         raise ValueError("this processing option is not implemented")
     return ds

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -518,13 +518,14 @@ def xclim_convert_360day_calendar_interpolate(
         return ds_out
 
 
-def apply_wet_day_frequency_correction(ds, process):
+def apply_wet_day_frequency_correction(ds, process, var='pr'):
     """
 
     Parameters
     ----------
     ds : xr.Dataset
     process : {"pre", "post"}
+    var: str
 
     Returns
     -------
@@ -546,14 +547,14 @@ def apply_wet_day_frequency_correction(ds, process):
 
     if process == "pre":
         # includes very small values that are negative in CMIP6 output
-        ds_corrected = ds.where(
-            ds > threshold, np.random.uniform(low=low, high=threshold)
+        ds[var] = ds[var].where(
+            ds[var] >= threshold, np.random.uniform(low=low, high=threshold, size=ds[var].shape)
         )
     elif process == "post":
-        ds_corrected = ds.where(ds >= threshold, 0.0)
+        ds[var] = ds[var].where(ds[var] >= threshold, 0.0)
     else:
         raise ValueError("this processing option is not implemented")
-    return ds_corrected
+    return ds
 
 
 def dtr_floor(ds, floor):

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -618,7 +618,7 @@ def remove_leapdays(x, out):
 
 
 @log_service
-def correct_wet_day_frequency(x, out, process):
+def correct_wet_day_frequency(x, out, process, var='pr'):
     """Corrects wet day frequency in a dataset
 
     Parameters
@@ -631,9 +631,10 @@ def correct_wet_day_frequency(x, out, process):
         Step in pipeline, used in determining how to correct.
         "Pre" replaces all zero values with a uniform random value below a threshold (before bias correction).
         "Post" replaces all values below a threshold with zeroes (after bias correction).
+    var: str
     """
     ds = storage.read(x)
-    ds_corrected = apply_wet_day_frequency_correction(ds, process=process)
+    ds_corrected = apply_wet_day_frequency_correction(ds, process=process, var=var)
     storage.write(out, ds_corrected)
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -618,7 +618,7 @@ def remove_leapdays(x, out):
 
 
 @log_service
-def correct_wet_day_frequency(x, out, process, var="pr"):
+def correct_wet_day_frequency(x, out, process, variable="pr"):
     """Corrects wet day frequency in a dataset
 
     Parameters
@@ -631,10 +631,10 @@ def correct_wet_day_frequency(x, out, process, var="pr"):
         Step in pipeline, used in determining how to correct.
         "Pre" replaces all zero values with a uniform random value below a threshold (before bias correction).
         "Post" replaces all values below a threshold with zeroes (after bias correction).
-    var: str
+    variable: str
     """
     ds = storage.read(x)
-    ds_corrected = apply_wet_day_frequency_correction(ds, process=process, var=var)
+    ds_corrected = apply_wet_day_frequency_correction(ds, process=process, variable=variable)
     storage.write(out, ds_corrected)
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -634,7 +634,9 @@ def correct_wet_day_frequency(x, out, process, variable="pr"):
     variable: str
     """
     ds = storage.read(x)
-    ds_corrected = apply_wet_day_frequency_correction(ds, process=process, variable=variable)
+    ds_corrected = apply_wet_day_frequency_correction(
+        ds, process=process, variable=variable
+    )
     storage.write(out, ds_corrected)
 
 

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -618,7 +618,7 @@ def remove_leapdays(x, out):
 
 
 @log_service
-def correct_wet_day_frequency(x, out, process, var='pr'):
+def correct_wet_day_frequency(x, out, process, var="pr"):
     """Corrects wet day frequency in a dataset
 
     Parameters

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -749,7 +749,9 @@ def test_correct_wet_day_frequency(process):
 
     seed = 1
     np.random.seed(seed)
-    correct_wet_day_frequency(in_url, out=out_url, process=process, variable="fakevariable")
+    correct_wet_day_frequency(
+        in_url, out=out_url, process=process, variable="fakevariable"
+    )
     ds_precip_corrected = repository.read(out_url)
 
     if process == "pre":

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -749,7 +749,7 @@ def test_correct_wet_day_frequency(process):
 
     seed = 1
     np.random.seed(seed)
-    correct_wet_day_frequency(in_url, out=out_url, process=process, var="fakevariable")
+    correct_wet_day_frequency(in_url, out=out_url, process=process, variable="fakevariable")
     ds_precip_corrected = repository.read(out_url)
 
     if process == "pre":

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -749,26 +749,37 @@ def test_correct_wet_day_frequency(process):
 
     seed = 1
     np.random.seed(seed)
-    correct_wet_day_frequency(in_url, out=out_url, process=process, var='fakevariable')
+    correct_wet_day_frequency(in_url, out=out_url, process=process, var="fakevariable")
     ds_precip_corrected = repository.read(out_url)
 
     if process == "pre":
         np.random.seed(seed)
         expected = np.random.uniform(0.5, 1, 4)
-        assert ds_precip_corrected.isel(time=0)['fakevariable'].values.item() == expected[0]
-        assert ds_precip_corrected.isel(time=3)['fakevariable'].values.item() == expected[3]
-        expected = ds_precip.isel(time=slice(1,3))['fakevariable'].values
-        np.testing.assert_almost_equal(ds_precip_corrected.isel(time=slice(1,3))['fakevariable'].values,
-                                       expected)
+        assert (
+            ds_precip_corrected.isel(time=0)["fakevariable"].values.item()
+            == expected[0]
+        )
+        assert (
+            ds_precip_corrected.isel(time=3)["fakevariable"].values.item()
+            == expected[3]
+        )
+        expected = ds_precip.isel(time=slice(1, 3))["fakevariable"].values
+        np.testing.assert_almost_equal(
+            ds_precip_corrected.isel(time=slice(1, 3))["fakevariable"].values, expected
+        )
 
     elif process == "post":
-        expected = 0.
-        assert ds_precip_corrected.isel(time=0)['fakevariable'].values.item() == expected
-        assert ds_precip_corrected.isel(time=3)['fakevariable'].values.item() == expected
-        expected = ds_precip.isel(time=slice(1,3))['fakevariable'].values
-        np.testing.assert_almost_equal(ds_precip_corrected.isel(time=slice(1,3))['fakevariable'].values,
-                                       expected)
-
+        expected = 0.0
+        assert (
+            ds_precip_corrected.isel(time=0)["fakevariable"].values.item() == expected
+        )
+        assert (
+            ds_precip_corrected.isel(time=3)["fakevariable"].values.item() == expected
+        )
+        expected = ds_precip.isel(time=slice(1, 3))["fakevariable"].values
+        np.testing.assert_almost_equal(
+            ds_precip_corrected.isel(time=slice(1, 3))["fakevariable"].values, expected
+        )
 
 
 def test_apply_dtr_floor():


### PR DESCRIPTION
- [x] closes #173 
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

essential changes : 

- in the core function, instead of using a unique replacement value, use an array of (likely) different values, in `process='pre'`
- values _strictly_ below 1 are modified, rather than below or equal to 1, in `process='pre'`. 
- make tests deterministic (with a `seed`), smaller and more precise. 

secondary changes : 

2. in the core function, directly operate on the data array object within the dataset -- which means I have to introduce a `var` parameter -- default value is `'pr'`, but in tests we have other variable names. Need that parameter in the service as well.
