### PR TITLE
drop spatial bounds coordinates if present in cmip6 cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Drop coordinate values associated with the spatial bounds dimension in CMIP6 cleaning (PR #177, @emileten).
 
 ## [0.16.1] - 2022-01-27
 ### Fixed

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -357,6 +357,10 @@ def standardize_gcm(ds, leapday_removal=True):
         coords_to_drop, drop=True
     )
 
+    # Some models have coordinates values (e.g. [1.0, 2.0]) for the spatial bounds dimension. We don't need this.
+    if 'bnds' in ds_cleaned.variables:
+        ds_cleaned = ds_cleaned.drop(['bnds']) # this preserves the dimension in itself but drops the coordinates values.
+
     # Cleanup time.
 
     # if variable is precip, need to update units to mm day-1

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -358,8 +358,10 @@ def standardize_gcm(ds, leapday_removal=True):
     )
 
     # Some models have coordinates values (e.g. [1.0, 2.0]) for the spatial bounds dimension. We don't need this.
-    if 'bnds' in ds_cleaned.variables:
-        ds_cleaned = ds_cleaned.drop(['bnds']) # this preserves the dimension in itself but drops the coordinates values.
+    if "bnds" in ds_cleaned.variables:
+        ds_cleaned = ds_cleaned.drop(
+            ["bnds"]
+        )  # this preserves the dimension in itself but drops the coordinates values.
 
     # Cleanup time.
 


### PR DESCRIPTION
- [ ] partially solves https://github.com/ClimateImpactLab/downscaleCMIP6/issues/494
- [ ] tests added / passed
- [ ] docs reflect changes
- [x] entry in CHANGELOG.md

The presence of coordinates values associated with the spatial bounds dimension can cause errors downstream, in particular when doing distributed regridding. We have an example of this kind of problem in the above linked issue.

Since the libraries we use do not need this information -- these libraries have been doing their job correctly when exposed to datasets that do not have these coordinates -- I decided to simply drop this information in cleaning. 

This only drops the coordinates, not the dimension, which we need. 