### PR TITLE
fix bad references 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix incorrect references when standardizing gcm (PR #178, @emileten)
 
 ## [0.16.1] - 2022-01-27
 ### Fixed

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -372,22 +372,22 @@ def standardize_gcm(ds, leapday_removal=True):
             # we want this to fail, as pr units are something we don't expect
             raise ValueError("check units: pr units attribute is not kg m-2 s-1")
 
-    cal = get_calendar(ds)
+    cal = get_calendar(ds_cleaned)
 
     if (
         cal == "360_day" or leapday_removal
     ):  # calendar conversion is necessary in either case
         # if calendar is just integers, xclim cannot understand it
-        if ds.time.dtype == "int64":
+        if ds_cleaned.time.dtype == "int64":
             ds_cleaned["time"] = xr.decode_cf(ds_cleaned).time
         if cal == "360_day":
             if leapday_removal:  # 360 day -> noleap
                 ds_converted = xclim_convert_360day_calendar_interpolate(
-                    ds=ds, target="noleap", align_on="random", interpolation="linear"
+                    ds=ds_cleaned, target="noleap", align_on="random", interpolation="linear"
                 )
             else:  # 360 day -> standard
                 ds_converted = xclim_convert_360day_calendar_interpolate(
-                    ds=ds, target="standard", align_on="random", interpolation="linear"
+                    ds=ds_cleaned, target="standard", align_on="random", interpolation="linear"
                 )
         else:  # any -> noleap
             # remove leap days and update calendar
@@ -395,7 +395,7 @@ def standardize_gcm(ds, leapday_removal=True):
 
         # rechunk, otherwise chunks are different sizes
         ds_out = ds_converted.chunk(
-            {"time": 730, "lat": len(ds.lat), "lon": len(ds.lon)}
+            {"time": 730, "lat": len(ds_cleaned.lat), "lon": len(ds_cleaned.lon)}
         )
 
     else:

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -383,11 +383,17 @@ def standardize_gcm(ds, leapday_removal=True):
         if cal == "360_day":
             if leapday_removal:  # 360 day -> noleap
                 ds_converted = xclim_convert_360day_calendar_interpolate(
-                    ds=ds_cleaned, target="noleap", align_on="random", interpolation="linear"
+                    ds=ds_cleaned,
+                    target="noleap",
+                    align_on="random",
+                    interpolation="linear",
                 )
             else:  # 360 day -> standard
                 ds_converted = xclim_convert_360day_calendar_interpolate(
-                    ds=ds_cleaned, target="standard", align_on="random", interpolation="linear"
+                    ds=ds_cleaned,
+                    target="standard",
+                    align_on="random",
+                    interpolation="linear",
                 )
         else:  # any -> noleap
             # remove leap days and update calendar


### PR DESCRIPTION
- [x] partially closes https://github.com/ClimateImpactLab/downscaleCMIP6/issues/439
- [ ] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

This fixes a few object reference mistakes in `dodola.core.standardize_gcm`, that were causing https://github.com/ClimateImpactLab/downscaleCMIP6/issues/439 but could have been in general more problematic. 


In the beginning of the function, a new transformed dataset object named `ds_cleaned` is created out of `ds`, but in subsequent calls, there are remaining references to `ds` where we should reference the transformed object instead. 

This fix mechanically solves /ClimateImpactLab/downscaleCMIP6/issues/439 (which I verified in this workflow : https://argo.cildc6.org/archived-workflows/default/6da813ba-47ba-45a0-95d8-36444e2bcf7b), because we actually drop the time bounds in `ds_cleaned`, which were causing the issue.