### PR TITLE
relocate data loading in standardize-gcm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Move in-memory data loading where it is needed for 360-days calendar conversion in clean-cmip6 (PR #179, @emileten)
 
 ## [0.16.2] - 2022-02-15
 ### Fixed

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -381,6 +381,11 @@ def standardize_gcm(ds, leapday_removal=True):
         if ds_cleaned.time.dtype == "int64":
             ds_cleaned["time"] = xr.decode_cf(ds_cleaned).time
         if cal == "360_day":
+
+            # Cannot have chunks in time dimension for 360 day calendar conversion so loading
+            # data into memory.
+            ds.load()
+
             if leapday_removal:  # 360 day -> noleap
                 ds_converted = xclim_convert_360day_calendar_interpolate(
                     ds=ds_cleaned,

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -384,7 +384,7 @@ def standardize_gcm(ds, leapday_removal=True):
 
             # Cannot have chunks in time dimension for 360 day calendar conversion so loading
             # data into memory.
-            ds.load()
+            ds_cleaned.load()
 
             if leapday_removal:  # 360 day -> noleap
                 ds_converted = xclim_convert_360day_calendar_interpolate(

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -593,10 +593,6 @@ def clean_cmip6(x, out, leapday_removal):
     """
     ds = storage.read(x)
 
-    # Cannot have chunks in time dimension for 360 day calendar conversion so loading
-    # data into memory.
-    ds.load()
-
     cleaned_ds = standardize_gcm(ds, leapday_removal)
     storage.write(out, cleaned_ds)
 


### PR DESCRIPTION
- [x] partially closes https://github.com/ClimateImpactLab/downscaleCMIP6/issues/574
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

@brews there is more detailed background information in https://github.com/ClimateImpactLab/downscaleCMIP6/issues/574, but here I summarize it : 

This PR directly modifies a previous one that had breaking changes : https://github.com/ClimateImpactLab/dodola/pull/151
Back then, the change was to load the data in memory in `dodola.services.clean_cmip6`, to fix chunking problems in the case where in the underlying `dodola.core.standardize_gcm`, `calendar == 360_day`. 

We observe in https://github.com/ClimateImpactLab/downscaleCMIP6/issues/574 that this PR broke runs with data that's too large for our nodes and the downstream computations. 

My suggested fix here is to simply move that data loading operation to where it's needed. It turns out that models with high resolution data _do not_ have a 360 days calendar. It's only luck, but I find this quick, cheap fix appealing. And loading operations are arguably part of `dodola.core`, since all the code inside of it relies on xarray datasets. 