### PR TITLE
Increase max allowed tasmin, tasmax in services.validate to 377 K for UKESM1-0-LL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Move in-memory data loading where it is needed for 360-days calendar conversion in clean-cmip6 (PR #179, @emileten)
 ### Changed
-- Increase max allowed tasmin, tasmax in services.validate to 377 K for UKESM1-0-LL. (@brews)
+- Increase max allowed tasmin, tasmax in services.validate to 377 K for UKESM1-0-LL. (PR #180, @brews)
 
 ## [0.16.2] - 2022-02-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Move in-memory data loading where it is needed for 360-days calendar conversion in clean-cmip6 (PR #179, @emileten)
+### Changed
+- Increase max allowed tasmin, tasmax in services.validate to 377 K for UKESM1-0-LL. (@brews)
 
 ## [0.16.2] - 2022-02-15
 ### Fixed

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -774,8 +774,10 @@ def _test_temp_range(ds, var):
     """
     Ensure temperature values are in a valid range
     """
+    # This high 377 K temperature range is to allow UKESM1-0-LL runs, which
+    # apparently run very hot.
     assert (ds[var].min() > 130) and (
-        ds[var].max() < 360
+        ds[var].max() < 377
     ), "{} values are invalid".format(var)
 
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

Increases the maximum temperature allowed by validation for tasmin and tasmax to 377 K. Without this change validation checks fail output from HadGEM3-GC31-11 (see https://github.com/ClimateImpactLab/downscaleCMIP6/issues/558) and UKESM1-0-LL (see https://github.com/ClimateImpactLab/downscaleCMIP6/issues/559).

It appears that UKESM1.0-LL SSP126 has a maximum daily value of 376.37 K.