### PR TITLE
Hack fix to validate OOM errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Fix dodola validate-dataset OOM on small workers without dask-distributed. (@brews)
 
 ## [0.17.0] - 2022-02-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix dodola validate-dataset OOM on small workers without dask-distributed. (@brews)
+- Fix dodola validate-dataset OOM on small workers without dask-distributed. (PR #181, @brews)
 
 ## [0.17.0] - 2022-02-17
 ### Changed

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -4,7 +4,6 @@ from functools import wraps
 import json
 import logging
 import dask
-import numpy as np
 from dodola.core import (
     xesmf_regrid,
     standardize_gcm,
@@ -763,7 +762,7 @@ def validate(x, var, data_type, time_period):
         return True
 
     tasks = []
-    for t in np.unique(ds["time"].dt.year.data):
+    for t in set(ds["time"].dt.year.data):
         logger.debug(f"Validating year {t}")
         tasks.append(memory_intensive_tests(x, var, t))
     tasks = dask.compute(*tasks)


### PR DESCRIPTION
- [x] closes #126
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

Fixes `dodola validate-dataset` failing with out-of-memory errors on small workers without external dask cluster. This was especially a problem on quality-control checks to 0.25 degree grid input data. 

This solution is somewhat hackish in that we're reading and subsetting the input data to year available year in `dodola.services` — essentially refactoring the larger validation flow from `dodola.core` to `dodola.services` so that we can keep all the storage I/O implementation details out of `dodola.core`. This is an adaptation of the solution to used in [this temporary fix](https://github.com/ClimateImpactLab/downscaleCMIP6/blob/18cf791d4c169e707d4ae072cd4c217f65658421/workflows/templates/qualitycontrol-check-cmip6.yaml).