### PR TITLE
Add CI/CD job for releases to GHCR

### DIFF
--- a/.github/workflows/buildpushrelease.yaml
+++ b/.github/workflows/buildpushrelease.yaml
@@ -70,3 +70,34 @@ jobs:
       run: |
         docker push "${{ env.release_image_name }}"
 
+  buildpushrelease-ghcr:
+    runs-on: ubuntu-latest
+    env:
+      HASH: $(git rev-parse --short "$GITHUB_SHA")
+      BRANCH: ${GITHUB_REF##*/}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image release tag
+        env:
+          FULL_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          echo "docker_tag=${FULL_RELEASE_TAG#v}" >> $GITHUB_ENV
+
+      - name: Set image name
+        run: |
+          echo "release_image_name=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ env.docker_tag }}" >> $GITHUB_ENV
+
+      - name: Build container
+        run: |
+          docker build . -t "${{ env.release_image_name }}"
+
+      - name: Push to registry
+        run: |
+          docker push "${{ env.release_image_name }}"


### PR DESCRIPTION
Add ghactions job pushing to the public Github Container Registry (at `ghcr.io/climateimpactlab/dodola`) on releases.