### PR TITLE
Fix setup-gcloud dropping master branch as default

### DIFF
--- a/.github/workflows/buildpush.yaml
+++ b/.github/workflows/buildpush.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Docker login
-        uses: google-github-actions/setup-gcloud@master
+        uses: 'google-github-actions/setup-gcloud@v0'
         with:
           service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/buildpushrelease.yaml
+++ b/.github/workflows/buildpushrelease.yaml
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Docker login
-      uses: google-github-actions/setup-gcloud@master
+      uses: 'google-github-actions/setup-gcloud@v0'
       with:
         service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
         project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
Fixes CI/CD failures like this https://github.com/ClimateImpactLab/dodola/runs/5653388487

Turns out setup-gcloud action changed its default branch from `master` and this breaks everything.

This PR applies the fix recommended in the error message.