### PR TITLE
Add test coverage reporting for CI container tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,11 @@ jobs:
         docker build . -t dodola:dev
     - name: Test package
       run: |
-        docker run dodola:dev pytest -v --pyargs dodola
+        docker run -w /opt/dodola --name testcontainer dodola:dev \
+          pytest -v --pyargs dodola --cov dodola --cov-report term-missing --cov-report xml
+        docker cp testcontainer:/opt/dodola/coverage.xml ./coverage.xml
     - name: Test CLI
       run: |
         docker run dodola:dev dodola --help
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Test coverage for container tests in CI. (@brews)
 
 ## [0.19.0] - 2022-03-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Test coverage for container tests in CI. (@brews)
+- Test coverage for container tests in CI. (PR #188, @brews)
 
 ## [0.19.0] - 2022-03-25
 ### Added

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,6 +13,7 @@ dependencies:
 - papermill=2.3.4  # Not direct dependency. Used in docker environment.
 - pip=22.0.3
 - pytest=7.0.1
+- pytest-cov
 - python=3.9
 - s3fs=2022.1.0
 - xarray=0.21.1


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

Adds to CI config so container tests report test coverage to codecov.