### PR TITLE
Migrate container to micromamba, setup.cfg to pyproject.toml, and add metadata labels to container

### DIFF
--- a/.github/workflows/buildpush.yaml
+++ b/.github/workflows/buildpush.yaml
@@ -19,12 +19,24 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image release tag
+        env:
+          FULL_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          echo "docker_tag=dev" >> $GITHUB_ENV
+
       - name: Set image name
         run: |
-          echo "image_name=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):dev" >> $GITHUB_ENV
+          echo "image_name=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ env.docker_tag }}" >> $GITHUB_ENV
+
       - name: Build container
         run: |
-          docker build . -t "${{ env.image_name }}"
+          docker build . -t "${{ env.image_name }}" \
+            --label "org.opencontainers.image.created=$(date --rfc-3339=ns)" \
+            --label "org.opencontainers.image.version=${{ env.docker_tag }}" \
+            --label "org.opencontainers.image.revision=${{ env.GITHUB_SHA }}"
+
       - name: Push to registry
         run: |
           docker push "${{ env.image_name }}"

--- a/.github/workflows/buildpush.yaml
+++ b/.github/workflows/buildpush.yaml
@@ -21,8 +21,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set image release tag
-        env:
-          FULL_RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           echo "docker_tag=dev" >> $GITHUB_ENV
 

--- a/.github/workflows/buildpushrelease.yaml
+++ b/.github/workflows/buildpushrelease.yaml
@@ -28,12 +28,15 @@ jobs:
 
       - name: Set image name
         run: |
-          echo "release_image_name=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ env.docker_tag }}" >> $GITHUB_ENV
+          echo "image_name=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ env.docker_tag }}" >> $GITHUB_ENV
 
       - name: Build container
         run: |
-          docker build . -t "${{ env.release_image_name }}"
+          docker build . -t "${{ env.image_name }}" \
+            --label "org.opencontainers.image.created=$(date --rfc-3339=ns)" \
+            --label "org.opencontainers.image.version=${{ env.docker_tag }}" \
+            --label "org.opencontainers.image.revision=${{ env.GITHUB_SHA }}"
 
       - name: Push to registry
         run: |
-          docker push "${{ env.release_image_name }}"
+          docker push "${{ env.image_name }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,14 +28,12 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set image release tag
-      env:
-        FULL_RELEASE_TAG: ${{ github.event.release.tag_name }}
       run: |
         echo "docker_tag=dev" >> $GITHUB_ENV
 
     - name: Set image name
       run: |
-        echo "image_name=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ env.docker_tag }}" >> $GITHUB_ENV
+        echo "image_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ env.docker_tag }}" >> $GITHUB_ENV
 
     - name: Build container
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,16 +26,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Set image release tag
+      env:
+        FULL_RELEASE_TAG: ${{ github.event.release.tag_name }}
+      run: |
+        echo "docker_tag=dev" >> $GITHUB_ENV
+
+    - name: Set image name
+      run: |
+        echo "image_name=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ env.docker_tag }}" >> $GITHUB_ENV
+
     - name: Build container
       run: |
-        docker build . -t dodola:dev
+        docker build . -t "${{ env.image_name }}" \
+          --label "org.opencontainers.image.created=$(date --rfc-3339=ns)" \
+          --label "org.opencontainers.image.version=${{ env.docker_tag }}" \
+          --label "org.opencontainers.image.revision=${{ env.GITHUB_SHA }}"
+
     - name: Test package
       run: |
-        docker run -w /opt/dodola --name testcontainer dodola:dev \
+        docker run -w /opt/dodola --name testcontainer "${{ env.image_name }}" \
           pytest -v --pyargs dodola --cov dodola --cov-report term-missing --cov-report xml
         docker cp testcontainer:/opt/dodola/coverage.xml ./coverage.xml
+
     - name: Test CLI
       run: |
-        docker run dodola:dev dodola --help
+        docker run "${{ env.image_name }}" dodola --help
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,9 +44,9 @@ jobs:
 
     - name: Test package
       run: |
-        docker run --name testcontainer "${{ env.image_name }}" \
+        docker run -w /opt/dodola --name testcontainer "${{ env.image_name }}" \
           pytest -v --pyargs dodola --cov dodola --cov-report term-missing --cov-report xml
-        docker cp testcontainer:coverage.xml ./coverage.xml
+        docker cp testcontainer:/opt/dodola/coverage.xml ./coverage.xml
 
     - name: Test CLI
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,9 +44,9 @@ jobs:
 
     - name: Test package
       run: |
-        docker run -w /opt/dodola --name testcontainer "${{ env.image_name }}" \
+        docker run --name testcontainer "${{ env.image_name }}" \
           pytest -v --pyargs dodola --cov dodola --cov-report term-missing --cov-report xml
-        docker cp testcontainer:/opt/dodola/coverage.xml ./coverage.xml
+        docker cp testcontainer:coverage.xml ./coverage.xml
 
     - name: Test CLI
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Test coverage for container tests in CI. (PR #188, PR #191, @brews)
+- Add `org.opencontainers.image` labels with metadata to container. (PR #195, @brews)
 ### Changed
-- Minor README updates, improvements. (@brews)
+- Migrate parent container from `miniconda3` to `micromamba`. Note this is a significant change to the container environment which may break scripts run in the container. In addition, the containers entry point has changed, breaking backwards compatibility for Argo Workflows running with Emissary executors. (PR #195, @brews)
+- Migrate Python package metadata and dependencies from `setup.cfg` to `pyproject.toml`. Note the runtime environment used in the container is still `environment.yaml`. (PR #195, @brews)
+- Minor README updates, improvements. (PR #195, @brews)
 
 ## [0.19.0] - 2022-03-25
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN micromamba install -y -f /tmp/env.yaml && \
     micromamba clean --all --yes
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-COPY --chown=$MAMBA_USER:$MAMBA_USER . /tmp/dodola
-RUN python -m pip install --no-deps /tmp/dodola
+COPY --chown=$MAMBA_USER:$MAMBA_USER . /opt/dodola
+RUN python -m pip install --no-deps -e /opt/dodola
 
 CMD ["dodola"]

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ test:
 format:
 	black dodola
 format-check:
-	flake8 --count --show-source --statistics
+	flake8 --count --show-source --statistics dodola
 	black -v --check dodola

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,11 +6,12 @@ dependencies:
 - dask=2022.2.0
 - click=8.0.3
 - cftime=1.5.2
-- intake=0.6.5  # Not direct dependency. Used in docker environment.
-- intake-esm=2021.8.17  # Not direct dependency. Used in docker environment.
+- intake=0.6.5  # Not direct dependency. Used in container environment.
+- intake-esm=2021.8.17  # Not direct dependency. Used in container environment.
 - gcsfs=2022.1.0
+- git  # Needed to pull pip requirement below in container build.
 - numpy=1.22.2
-- papermill=2.3.4  # Not direct dependency. Used in docker environment.
+- papermill=2.3.4  # Not direct dependency. Used in container environment.
 - pip=22.0.3
 - pytest=7.0.1
 - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     "click == 8.0.3",
     "cftime == 1.5.2",
     "numpy == 1.22.2",
-    "xarray == 0.21",
-    "xclim == 0.30.1",
+    "xarray == 0.21.1",
+    "xclim >= 0.30.1",
     "xesmf == 0.6.2",
     "zarr == 2.11.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,57 @@
 [build-system]
 requires = [
-    "setuptools>=42",
-    "wheel",
+    "setuptools>=62.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "dodola"
+version = "0.1.0a0"
+description = "GCM bias-correction and downscaling"
+readme = "README.md"
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: OS Independent",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "dask == 2022.2.0",
+    "click == 8.0.3",
+    "cftime == 1.5.2",
+    "numpy == 1.22.2",
+    "xarray == 0.21",
+    "xclim == 0.30.1",
+    "xesmf == 0.6.2",
+    "zarr == 2.11.0",
+]
+
+[project.optional-dependencies]
+complete = [
+    "adlfs == 2022.2.0",
+    "intake == 0.6.5",
+    "intake-esm == 2021.8.17",
+    "gcsfs == 2022.1.0",
+    "papermill == 2.3.4",
+    "s3fs == 2022.1.0",
+]
+test = [
+    "pytest == 7.0.1",
+    "pytest-cov"
+]
+
+
+[project.urls]
+Homepage = "https://github.com/ClimateImpactLab/dodola"
+"Bug Tracker" = "https://github.com/ClimateImpactLab/dodola/issues"
+
+[project.scripts]
+dodola = "dodola.cli:dodola_cli"
+
+[tool.setuptools]
+packages = ["dodola"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,31 +1,3 @@
-[metadata]
-name = dodola
-version = 0.1.0a0
-description = GCM bias-correction and downscaling
-long_description = file: README.md
-long_description_content_type = text/markdown
-url = https://github.com/ClimateImpactLab/dodola
-project_urls =
-    Bug Tracker = https://github.com/ClimateImpactLab/dodola/issues
-classifiers =
-    Development Status :: 2 - Pre-Alpha
-    Intended Audience :: Developers
-    Intended Audience :: Science/Research
-    License :: OSI Approved :: Apache Software License
-    Natural Language :: English
-    Programming Language :: Python :: 3
-    Topic :: Scientific/Engineering
-    Operating System :: OS Independent
-
-[options]
-package_dir =
-    dodola = dodola
-python_requires = >=3.8
-
-[options.entry_points]
-console_scripts =
-    dodola = dodola.cli:dodola_cli
-
 [flake8]
 exclude = docs
 ignore = E203,E266,E402,E501,W503,F401,C901


### PR DESCRIPTION
- [x] closes #192, #193
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

Quite a few big and potentially breaking changes in this PR.

- The container's parent image has changed from `continuumio/miniconda3:4.10.3` to `mambaorg/micromamba:0.23.0`. Hopefully this will help make the container lighter, faster, and more secure. This is a breaking change because this uses a different entrypoint in the container -- meaning that any users running this as part of an Argo Workflow with an Emissary executor will _likely_ need to update the `....container.command` used by the template to `["/usr/local/bin/_entrypoint.sh", "dodola"]`. I've noted this in the CHANGELOG.
- Most of the package specs, including the basic dependencies have been migrated from `setup.cfg` to `pyproject.toml`. setuptools now has experimental support for `pyproject.toml` so we should take advantage of that upgrade as soon as possible. Adding basic dodola package dependencies to the file also means that Github and maybe dependabot will also note our dependencies.
- The container is now built with various labels following the [opencontainer annotation spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md). My hope is that this might be easier to track down this container and its changes in the future as it spreads around and gets used.