### PR TITLE
Add docs with pdocs CD workflow to Github Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,7 @@ jobs:
           extra-specs: |
             pdoc
       - run: pip install -e .
-      - run: pdoc -o docs/ dodola --docformat numpy
+      - run: make docs
       - run: tar --directory docs/ -hcf artifact.tar .
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,47 @@
+name: website
+
+# build the documentation whenever there are new commits on main
+on:
+  push:
+    branches:
+      - main
+
+# security: restrict permissions for CI jobs.
+permissions:
+  contents: read
+
+jobs:
+  # Build the documentation and upload the static HTML files as an artifact.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup micromamba
+        uses: mamba-org/provision-with-micromamba@v12
+        with:
+          environment-file: environment.yaml
+          cache-downloads: true
+          extra-specs: |
+            pdoc
+      - run: pip install -e .
+      - run: pdoc -o docs/ dodola --docformat numpy
+      - run: tar --directory docs/ -hcf artifact.tar .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: github-pages
+          path: ./artifact.tar
+
+  # Deploy the artifact to GitHub pages.
+  # This is a separate job so that only actions/deploy-pages has the necessary permissions.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add documentation, hosted at https://climateimpactlab.github.io/dodola/. (@brews)
+- Add documentation, hosted at https://climateimpactlab.github.io/dodola/. (PR #205, @brews)
 - Test coverage for container tests in CI. (PR #188, PR #191, @brews)
 - Add `org.opencontainers.image` labels with metadata to container. (PR #195, @brews)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add documentation, hosted at https://climateimpactlab.github.io/dodola/. (@brews)
 - Test coverage for container tests in CI. (PR #188, PR #191, @brews)
 - Add `org.opencontainers.image` labels with metadata to container. (PR #195, @brews)
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,5 @@ format:
 format-check:
 	flake8 --count --show-source --statistics dodola
 	black -v --check dodola
+docs:
+	pdoc -o docs/ dodola --docformat numpy

--- a/README.md
+++ b/README.md
@@ -73,4 +73,6 @@ Because there are many compiled dependencies we recommend installing `dodola` an
 
 ## Support
 
+Additional technical documentation is available online at https://climateimpactlab.github.io/dodola/.
+
 Source code is available online at https://github.com/ClimateImpactLab/dodola. This software is Open Source and available under the Apache License, Version 2.0.

--- a/dodola/__init__.py
+++ b/dodola/__init__.py
@@ -1,0 +1,3 @@
+"""
+.. include:: ../README.md
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ test = [
     "pytest == 7.0.1",
     "pytest-cov"
 ]
+docs = [
+    "pdoc",
+]
 
 
 [project.urls]


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

Adds automated doc builds/deploy with [pdoc](https://pdoc.dev/). Changes should be deployed to https://climateimpactlab.github.io/dodola/ on pushes to `main`.

We'll try this out and see how it goes.