### PR TITLE
Update pkg metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate parent container from `miniconda3` to `micromamba`. Note this is a significant change to the container environment which may break scripts run in the container. In addition, the containers entry point has changed, breaking backwards compatibility for Argo Workflows running with Emissary executors. (PR #195, @brews)
 - Migrate Python package metadata and dependencies from `setup.cfg` to `pyproject.toml`. Note the runtime environment used in the container is still `environment.yaml`. (PR #195, @brews)
 - Minor README updates, improvements. (PR #195, @brews)
+- Updates to Python package metadata, specific dependencies, versioning, classifiers, project URLs. (PR #206, @brews)
 
 ## [0.19.0] - 2022-03-25
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version = "0.1.0a0"
 description = "GCM bias-correction and downscaling"
 readme = "README.md"
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
@@ -42,7 +42,9 @@ docs = [
 
 
 [project.urls]
-Homepage = "https://github.com/ClimateImpactLab/dodola"
+Homepage = "https://climateimpactlab.github.io/dodola"
+Documentation = "https://climateimpactlab.github.io/dodola"
+Source = "https://github.com/ClimateImpactLab/dodola"
 "Bug Tracker" = "https://github.com/ClimateImpactLab/dodola/issues"
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
 requires = [
     "setuptools>=62.0",
+    "wheel",
+    "setuptools_scm>=7.0",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "dodola"
-version = "0.1.0a0"
 description = "GCM bias-correction and downscaling"
 readme = "README.md"
 classifiers = [
@@ -52,3 +53,7 @@ dodola = "dodola.cli:dodola_cli"
 
 [tool.setuptools]
 packages = ["dodola"]
+
+[tool.setuptools_scm]
+fallback_version = "999"
+write_to = "dodola/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ build-backend = "setuptools.build_meta"
 name = "dodola"
 description = "GCM bias-correction and downscaling"
 readme = "README.md"
+dynamic = ["version"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,27 +21,19 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "dask == 2022.2.0",
-    "click == 8.0.3",
-    "cftime == 1.5.2",
-    "numpy == 1.22.2",
-    "xarray == 0.21.1",
+    "dask >= 2022.0.0",
+    "click >= 8.0.0",
+    "cftime",
+    "numpy >= 1.22.0",
+    "xarray >= 0.21.0",
     "xclim >= 0.30.1",
-    "xesmf == 0.6.2",
-    "zarr == 2.11.0",
+    "xesmf >= 0.6.0",
+    "zarr",
 ]
 
 [project.optional-dependencies]
-complete = [
-    "adlfs == 2022.2.0",
-    "intake == 0.6.5",
-    "intake-esm == 2021.8.17",
-    "gcsfs == 2022.1.0",
-    "papermill == 2.3.4",
-    "s3fs == 2022.1.0",
-]
 test = [
-    "pytest == 7.0.1",
+    "pytest",
     "pytest-cov"
 ]
 docs = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = docs
+exclude = docs,build,dist
 ignore = E203,E266,E402,E501,W503,F401,C901
 max-line-length = 100
 max-complexity = 18


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md

Updates package metadata.
- Loosens abstract dependency pins. These were too tight, to begin with. Note these are the abstract dependencies for the dodola python package and not the environment pins in the deployed container.
- Updates package metadata URLs.
- Updates package metadata classifiers.
- The dodola python package now versions itself on install dynamically based on git hashes and tags. It falls back on version "999" when it builds and git data is not available (e.g. in the containers).

In addition, this fixes the `flake8` config so that it avoids checking build artifacts.