### PR TITLE
Fix broken pint use in xclim

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
 - numpy=1.22.2
 - papermill=2.3.4  # Not direct dependency. Used in container environment.
 - pip=22.0.3
-- pint<0.20
+- pint<0.20  # Not a direct dependency but required for this old xclim fork: git+https://github.com/ClimateImpactLab/xclim@63023d27f89a457c752568ffcec2e9ce9ad7a81a
 - pytest=7.0.1
 - pytest-cov
 - python=3.9

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,6 +13,7 @@ dependencies:
 - numpy=1.22.2
 - papermill=2.3.4  # Not direct dependency. Used in container environment.
 - pip=22.0.3
+- pint<=0.20
 - pytest=7.0.1
 - pytest-cov
 - python=3.9

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
 - numpy=1.22.2
 - papermill=2.3.4  # Not direct dependency. Used in container environment.
 - pip=22.0.3
-- pint<=0.20
+- pint<0.20
 - pytest=7.0.1
 - pytest-cov
 - python=3.9


### PR DESCRIPTION
`xclim` has recently failed to import `pint.unit` in CI tests. Pinning to earlier version of `pint` (pint < 0.20.0) sub-dependency to work around this without radically changing how we handle dependencies and environment builds.

Examples of this failure:
https://github.com/ClimateImpactLab/dodola/actions/runs/3410997828/jobs/5674649890
https://github.com/ClimateImpactLab/dodola/actions/runs/3322139201/jobs/5490744399
from PR #212 and PR #213.

I don't think this will change the way the package runs. This is an internal maintenance thing.