### PR TITLE
Fix broken env from esmf/xesmf

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -6,6 +6,7 @@ dependencies:
 - dask=2022.2.0
 - click=8.0.3
 - cftime=1.5.2
+- esmf=8.3.1  # Required by old release of xesmf.
 - intake=0.6.5  # Not direct dependency. Used in container environment.
 - intake-esm=2021.8.17  # Not direct dependency. Used in container environment.
 - gcsfs=2022.1.0


### PR DESCRIPTION
Add and pin esmf to environment file. Pinning it to version just before it breaks compatibility with the version of xesmf we're running.

Considering conda-lock.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] docs reflect changes
- [ ] entry in CHANGELOG.md

[summarize your pull request here]