### PR TITLE
Minor format updating with black 23.1.0.

### DIFF
--- a/dodola/core.py
+++ b/dodola/core.py
@@ -380,7 +380,6 @@ def standardize_gcm(ds, leapday_removal=True):
         if ds_cleaned.time.dtype == "int64":
             ds_cleaned["time"] = xr.decode_cf(ds_cleaned).time
         if cal == "360_day":
-
             # Cannot have chunks in time dimension for 360 day calendar conversion so loading
             # data into memory.
             ds_cleaned.load()

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -359,7 +359,6 @@ def test_qplad_integration_af_quantiles():
 
 
 def test_xclim_units_conversion():
-
     initial_unit = "mm d-1"
     cf_style = _timeseriesfactory(
         np.ones(1),
@@ -374,7 +373,6 @@ def test_xclim_units_conversion():
 
 
 def test_xclim_convert_360day_calendar_interpolate():
-
     """Test that conversions of a 360-day-calendar time indexed dataset work"""
 
     # fake data

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -738,7 +738,6 @@ def test_remove_leapdays():
 
 @pytest.mark.parametrize("process", [pytest.param("pre"), pytest.param("post")])
 def test_correct_wet_day_frequency(process):
-
     """Test that wet day frequency correction corrects the frequency of wet days"""
     # Make some fake precip data
     ts = np.array([0.5, 1, 1.5, 0.1])


### PR DESCRIPTION
Recently `black` has broke backwards compatibility with its style changes, causing our simple CI linting checks to fail PRs. This PR updates the code style with a newer version of `black` to clear up the CI failures.

This should have no impact on functionality.