### PR TITLE
Update docs, comments language to be more consistent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test coverage for container tests in CI. (PR #188, PR #191, @brews)
 - Add `org.opencontainers.image` labels with metadata to container. (PR #195, @brews)
 ### Changed
+- Minor clarifications to docs and comments. (PR #232, @brews)
 - Migrate parent container from `miniconda3` to `micromamba`. Note this is a significant change to the container environment which may break scripts run in the container. In addition, the containers entry point has changed, breaking backwards compatibility for Argo Workflows running with Emissary executors. (PR #195, @brews)
 - Migrate Python package metadata and dependencies from `setup.cfg` to `pyproject.toml`. Note the runtime environment used in the container is still `environment.yaml`. (PR #195, @brews)
 - Minor README updates, improvements. (PR #195, @brews)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # dodola
 
-Containerized application for running individual tasks in a larger, orchestrated CMIP6 bias-correction and downscaling workflow.
+Containerized application for running individual tasks in a larger, orchestrated CMIP6 bias-adjustment and downscaling workflow.
 
 This is under heavy development.
 

--- a/dodola/cli.py
+++ b/dodola/cli.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--debug/--no-debug", default=False, envvar="DODOLA_DEBUG")
 def dodola_cli(debug):
-    """GCM bias-correction and downscaling
+    """GCM bias adjustment and downscaling
 
     Authenticate with storage by setting the appropriate environment variables
     for your fsspec-compatible URL library.
@@ -200,7 +200,7 @@ def apply_qdm(
     root_attrs_json_file=None,
     new_attrs=None,
 ):
-    """Adjust simulation years with QDM bias correction method, outputting Zarr Store"""
+    """Adjust simulation years with QDM bias-adjustment method, outputting Zarr Store"""
     first_year, last_year = (int(x) for x in years.split(","))
 
     unpacked_attrs = None
@@ -350,7 +350,7 @@ def train_qdm(
     "--wetday-post-correction",
     type=bool,
     default=False,
-    help="Whether to apply wet day frequency correction on downscaled data",
+    help="Whether to apply wet day frequency adjustment on downscaled data",
 )
 def apply_qplad(
     simulation,

--- a/dodola/core.py
+++ b/dodola/core.py
@@ -1,4 +1,4 @@
-"""Core logic for bias-correction and downscaling
+"""Core logic for bias adjustment and downscaling
 
 Math stuff and business logic goes here. This is the "business logic".
 """
@@ -93,7 +93,7 @@ def adjust_quantiledeltamapping(
     out : xr.Dataset
         QDM-adjusted values from `simulation`. May be a lazy-evaluated future, not
         yet computed. In addition to adjusted original variables, this includes
-        "sim_q" variable giving quantiles from QDM biascorrection.
+        "sim_q" variable giving quantiles from QDM biasadjustment.
     """
     # This loop is a candidate for dask.delayed. Beware, xclim had issues with saturated scheduler.
     qdm_list = []
@@ -725,11 +725,11 @@ def test_temp_range(ds, var):
 def test_dtr_range(ds, var, data_type):
     """
     Ensure DTR values are in a valid range
-    Test polar values separately since some polar values can be much higher post-bias correction.
+    Test polar values separately since some polar values can be much higher post bias adjustment.
     """
     # test that DTR values are greater than 0 or equal to 0 depending on the data type
     # note that some CMIP6 DTR will equal 0 at polar latitudes, this will be adjusted
-    # before bias correction with the DTR small values correction
+    # before bias adjustment with the DTR small values correction
 
     dtr_min = ds[var].min()
     if data_type == "cmip6":

--- a/dodola/services.py
+++ b/dodola/services.py
@@ -436,7 +436,7 @@ def apply_qplad(
     simulation : str
         fsspec-compatible URL containing simulation data to be adjusted.
         Dataset must have `variable` as well as a variable, "sim_q", giving
-        the quantiles from QDM bias-correction.
+        the quantiles from QDM bias adjustment.
     qplad : str
         fsspec-compatible URL pointing to Zarr Store containing canned
         ``xclim.sdba.adjustment.AnalogQuantilePreservingDownscaling`` Dataset.
@@ -632,8 +632,8 @@ def correct_wet_day_frequency(x, out, process, variable="pr"):
         Storage URL to write regridded output to.
     process : {"pre", "post"}
         Step in pipeline, used in determining how to correct.
-        "Pre" replaces all zero values with a uniform random value below a threshold (before bias correction).
-        "Post" replaces all values below a threshold with zeroes (after bias correction).
+        "Pre" replaces all zero values with a uniform random value below a threshold (before bias adjustment).
+        "Post" replaces all values below a threshold with zeroes (after bias adjustment).
     variable: str
     """
     ds = storage.read(x)

--- a/dodola/tests/test_core.py
+++ b/dodola/tests/test_core.py
@@ -251,7 +251,7 @@ def test_qplad_integration_af_quantiles():
     ds_bc[variable].attrs["units"] = "K"
 
     # this is an integration test between QDM and QPLAD, so use QDM services
-    # for bias correction
+    # for bias adjustment
     target_year = 2005
     qdm_model = train_quantiledeltamapping(
         reference=ds_ref_coarse, historical=ds_train, variable=variable, kind=kind

--- a/dodola/tests/test_services.py
+++ b/dodola/tests/test_services.py
@@ -1115,7 +1115,7 @@ def test_qplad_integration(kind):
     repository.write(sim_url, ds_bc)
 
     # this is an integration test between QDM and QPLAD, so use QDM services
-    # for bias correction
+    # for bias adjustment
     target_year = 2005
 
     train_qdm(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dodola"
-description = "GCM bias-correction and downscaling"
+description = "GCM bias adjustment and downscaling"
 readme = "README.md"
 dynamic = ["version"]
 classifiers = [


### PR DESCRIPTION
We've been slopping about calling the method "bias correction" or "bias adjustment" interchangeably. Some have been confused by this. Would like to be more consistent. This PR updates several cases in docs and comments to use "adjustment".

- [x] closes #xxxx
- [x] tests added / passed
- [x] docs reflect changes
- [x] entry in CHANGELOG.md